### PR TITLE
fix: update patches to work with latest signalk-server

### DIFF
--- a/patch_latest/mdns.patch
+++ b/patch_latest/mdns.patch
@@ -35,18 +35,18 @@ Tested with full test suite (136 passing) on Node 18, 20, 22, and 24.
  4 files changed, 167 insertions(+), 103 deletions(-)
 
 diff --git a/package.json b/package.json
-index b0b37ee81..cde3a1a6d 100644
+index dd00bc9..61e0adf 100644
 --- a/package.json
 +++ b/package.json
-@@ -69,6 +69,7 @@
-     "packages/typedoc-theme"
-   ],
+@@ -72,6 +72,7 @@
    "dependencies": {
+     "@assemblyscript/loader": "^0.28.9",
+     "@bytecodealliance/jco": "^1.4.0",
 +    "@homebridge/ciao": "^1.3.4",
-     "@js-temporal/polyfill": "^0.5.1",
      "@signalk/course-provider": "^1.0.0",
      "@signalk/n2k-signalk": ">=4.1.0-beta",
-@@ -91,7 +92,6 @@
+     "@signalk/nmea0183-signalk": "^3.0.0",
+@@ -95,7 +96,6 @@
      "cookie-parser": "^1.4.3",
      "cors": "^2.5.2",
      "debug": "^4.3.3",
@@ -54,7 +54,7 @@ index b0b37ee81..cde3a1a6d 100644
      "errorhandler": "^1.3.0",
      "esm-resolve": "^1.0.11",
      "express": "^4.10.4",
-@@ -131,7 +131,6 @@
+@@ -136,7 +136,6 @@
      "@signalk/signalk-to-nmea0183": "^1.0.0",
      "@signalk/udp-nmea-plugin": "^2.0.0",
      "@signalk/vesselpositions": "^1.0.0",
@@ -63,21 +63,31 @@ index b0b37ee81..cde3a1a6d 100644
      "signalk-n2kais-to-nmea0183": "^1.3.1",
      "signalk-to-nmea2000": "^2.16.0"
 diff --git a/src/index.ts b/src/index.ts
-index b07e67ed5..a0995eea8 100644
+index 113a411..e7f7bde 100644
 --- a/src/index.ts
 +++ b/src/index.ts
-@@ -549,51 +549,64 @@ class Server {
-       if (!this.app.started) {
-         resolve(this)
-       } else {
--        try {
--          _.each(this.app.interfaces, (intf: any) => {
--            if (
--              intf !== null &&
--              typeof intf === 'object' &&
--              typeof intf.stop === 'function'
--            ) {
--              intf.stop()
+@@ -544,58 +544,71 @@ class Server {
+     return this
+   }
+
+-  async stop(cb?: () => void) {
+-    if (!this.app.started) {
+-      return this
+-    }
+-
+-    try {
+-      _.each(this.app.interfaces, (intf: any) => {
+-        if (
+-          intf !== null &&
+-          typeof intf === 'object' &&
+-          typeof intf.stop === 'function'
+-        ) {
+-          intf.stop()
++  stop(cb?: () => void) {
++    return new Promise((resolve, reject) => {
++      if (!this.app.started) {
++        resolve(this)
++      } else {
 +        // Stop all interfaces (some may be async)
 +        const stopInterfaces = async () => {
 +          const stopPromises = Object.values(this.app.interfaces).map(
@@ -92,30 +102,21 @@ index b07e67ed5..a0995eea8 100644
 +                return result instanceof Promise ? result : Promise.resolve()
 +              }
 +              return Promise.resolve()
-             }
--          })
--
--          this.app.intervals.forEach((interval) => {
--            clearInterval(interval)
--          })
--
--          this.app.providers.forEach((providerHolder) => {
--            providerHolder.pipeElements[0].end()
--          })
--
--          debug('Closing server...')
++            }
 +          )
 +          await Promise.all(stopPromises)
-+        }
- 
--          const that = this
--          this.app.server.close(() => {
--            debug('Server closed')
--            if (that.app.redirectServer) {
--              try {
--                that.app.redirectServer.close(() => {
--                  debug('Redirect server closed')
--                  delete that.app.redirectServer
+         }
+-      })
+-
+-      this.app.intervals.forEach((interval) => {
+-        clearInterval(interval)
+-      })
+-
+-      this.app.providers.forEach((providerHolder) => {
+-        providerHolder.pipeElements[0].end()
+-      })
+
+-      debug('Closing server...')
 +        stopInterfaces()
 +          .catch((err) => debug('Error stopping interfaces:', err))
 +          .then(() => {
@@ -123,7 +124,19 @@ index b07e67ed5..a0995eea8 100644
 +              this.app.intervals.forEach((interval) => {
 +                clearInterval(interval)
 +              })
-+
+
+-      const that = this
+-      return new Promise((resolve, reject) => {
+-        this.app.server.close(() => {
+-          debug('Server closed')
+-          if (that.app.redirectServer) {
+-            try {
+-              that.app.redirectServer.close(() => {
+-                debug('Redirect server closed')
+-                delete that.app.redirectServer
+-                that.app.started = false
+-                cb && cb()
+-                resolve(that)
 +              this.app.providers.forEach((providerHolder) => {
 +                providerHolder.pipeElements[0].end()
 +              })
@@ -146,31 +159,32 @@ index b07e67ed5..a0995eea8 100644
 +                    reject(err)
 +                  }
 +                } else {
-                   that.app.started = false
-                   cb && cb()
-                   resolve(that)
--                })
--              } catch (err) {
--                reject(err)
--              }
--            } else {
--              that.app.started = false
--              cb && cb()
--              resolve(that)
++                  that.app.started = false
++                  cb && cb()
++                  resolve(that)
 +                }
-+              })
-+            } catch (err) {
-+              reject(err)
+               })
+             } catch (err) {
+               reject(err)
              }
-           })
--        } catch (err) {
--          reject(err)
--        }
-       }
-     })
+-          } else {
+-            that.app.started = false
+-            cb && cb()
+-            resolve(that)
+-          }
+-        })
+-      })
+-    } catch (err) {
+-      throw err
+-    }
++          })
++      }
++    })
    }
+ }
+
 diff --git a/src/mdns.js b/src/mdns.js
-index 3d366b681..2d4a6d5d2 100644
+index 3d366b6..2d4a6d5 100644
 --- a/src/mdns.js
 +++ b/src/mdns.js
 @@ -19,112 +19,164 @@
@@ -180,10 +194,10 @@ index 3d366b681..2d4a6d5d2 100644
 -const dnssd = require('dnssd2')
 +const ciao = require('@homebridge/ciao')
  const ports = require('./ports')
- 
+
  module.exports = function mdnsResponder(app) {
    const config = app.config
- 
+
 -  let mdns = dnssd
 -
 -  try {
@@ -198,7 +212,7 @@ index 3d366b681..2d4a6d5d2 100644
      debug('Mdns disabled by configuration')
      return
    }
- 
+
 +  // Create a single responder instance for all services
 +  const responder = ciao.getResponder()
 +
@@ -217,7 +231,7 @@ index 3d366b681..2d4a6d5d2 100644
 -
 -  // Strip all the null or empty props in txtRecord
    txtRecord = _.pickBy(txtRecord, _.identity)
- 
+
 -  const types = []
 -  types.push({
 -    type: app.config.settings.ssl ? mdns.tcp('https') : mdns.tcp('http'),
@@ -232,7 +246,7 @@ index 3d366b681..2d4a6d5d2 100644
 +    port: ports.getExternalPort(app),
 +    txt: txtRecord
    })
- 
+
 +  // Additional services from interfaces
    for (const key in app.interfaces) {
      if (
@@ -268,7 +282,7 @@ index 3d366b681..2d4a6d5d2 100644
        }
      }
    }
- 
+
 -  const options = {
 -    txtRecord,
 -    txt: txtRecord
@@ -293,7 +307,7 @@ index 3d366b681..2d4a6d5d2 100644
 +        debug('Stopping flag set, skipping remaining services')
 +        break
 +      }
- 
+
 -  if (host !== require('os').hostname()) {
 -    options.host = host
 -  }
@@ -307,7 +321,7 @@ index 3d366b681..2d4a6d5d2 100644
 +          txt: svc.txt,
 +          ...serviceOptions
 +        })
- 
+
 -  debug(options)
 -
 -  const ads = []
@@ -348,7 +362,7 @@ index 3d366b681..2d4a6d5d2 100644
 +      }
 +    }
    }
- 
+
 +  // Start advertising (track the promise so we can wait for it on stop)
 +  advertisingPromise = startAdvertising().catch((err) => {
 +    if (!stopping) {
@@ -401,15 +415,15 @@ index 3d366b681..2d4a6d5d2 100644
    }
  }
 diff --git a/src/types.ts b/src/types.ts
-index d29977a05..7b65674dc 100644
+index d29977a..7b65674 100644
 --- a/src/types.ts
 +++ b/src/types.ts
 @@ -24,7 +24,7 @@ export interface SignalKServer extends ServerAPI {
- 
+
  export class Interface {
    start?: () => void
 -  stop?: () => void
 +  stop?: () => void | Promise<void>
    mdns?: MdnsAdvertisement
  }
- 
+

--- a/patch_latest/webpack-to-vite.patch
+++ b/patch_latest/webpack-to-vite.patch
@@ -2,47 +2,36 @@ diff --git a/.prettierignore b/.prettierignore
 index 1ece09ce1..17fba36cc 100644
 --- a/.prettierignore
 +++ b/.prettierignore
-@@ -3,3 +3,4 @@ public
- 
- **/*.mbtiles
- **/*.pmtiles
+@@ -7,3 +7,4 @@ examples/wasm-plugins/*/assembly
+ packages/assemblyscript-plugin-sdk/assembly
+ # AssemblyScript build outputs
+ packages/assemblyscript-plugin-sdk/build
 +**/.__mf__temp
 diff --git a/eslint.config.js b/eslint.config.js
 index 8437dadbe..87fe65da2 100644
 --- a/eslint.config.js
 +++ b/eslint.config.js
-@@ -7,7 +7,7 @@ const react = require('eslint-plugin-react')
- const chai = require('eslint-plugin-chai-friendly')
- 
- module.exports = defineConfig([
--  globalIgnores(['**/public', '**/dist']),
-+  globalIgnores(['**/public', '**/dist', '**/.__mf__temp']),
- 
+@@ -17,7 +17,8 @@ module.exports = defineConfig([
+     // Auto-generated WASM bindings (created by AssemblyScript compiler)
+     'examples/wasm-plugins/**/build/**',
+     'examples/wasm-plugins/**/plugin.js',
+     'examples/wasm-plugins/**/plugin.d.ts',
+-    'packages/assemblyscript-plugin-sdk/build/**'
++    'packages/assemblyscript-plugin-sdk/build/**',
++    '**/.__mf__temp'
+   ]),
+
    // TypeScript options
-   {
-diff --git a/package.json b/package.json
-index a85115109..ba25b283c 100644
---- a/package.json
-+++ b/package.json
-@@ -140,7 +140,7 @@
-     "@eslint-react/eslint-plugin": "^1.45.1",
-     "@eslint/js": "^9.24.0",
-     "@signalk/typedoc-signalk-theme": "^0.3.0",
--    "@tsconfig/node20": "^20.1.5",
-+    "@tsconfig/node20": "^20.1.8",
-     "@types/baconjs": "^0.7.34",
-     "@types/busboy": "^1.5.0",
-     "@types/chai": "^4.2.15",
 diff --git a/packages/server-admin-ui/.gitignore b/packages/server-admin-ui/.gitignore
 index 4667e0cb6..9f4484289 100644
 --- a/packages/server-admin-ui/.gitignore
 +++ b/packages/server-admin-ui/.gitignore
 @@ -9,6 +9,7 @@ coverage
- 
+
  # production
  public
 +.__mf__temp
- 
+
  # misc
  .DS_Store
 diff --git a/packages/server-admin-ui/index.html b/packages/server-admin-ui/index.html
@@ -140,7 +129,7 @@ index cd0bf444a..6581fdb4c 100644
 +
  .card {
    margin-bottom: 1.5 * $spacer;
- 
+
    // Cards with color accent
    @each $color, $value in $theme-colors {
      &.bg-#{$color} {
@@ -156,13 +145,13 @@ index cd0bf444a..6581fdb4c 100644
    }
 @@ -42,7 +45,7 @@
      }
- 
+
      .nav-link {
 -      padding: $card-spacer-y $card-spacer-x / 2;
 +      padding: $card-spacer-y math.div($card-spacer-x, 2);
        color: $text-muted;
        border-top: 0;
- 
+
 @@ -107,7 +110,7 @@
  // Card Actions
  .card-header {
@@ -173,7 +162,7 @@ index cd0bf444a..6581fdb4c 100644
    .card-actions {
      position: absolute;
 @@ -166,8 +169,8 @@
- 
+
  .card-full {
    margin-top: -$spacer;
 -  margin-right: -$grid-gutter-width / 2;
@@ -199,7 +188,7 @@ index c373d46ca..c2ffcfe0a 100644
 +  padding-left: math.div($grid-gutter-width, 4);
 +  margin-right: math.div($grid-gutter-width, -2);
 +  margin-left: math.div($grid-gutter-width, -2);
- 
+
    [class*='col-'] {
 -    padding-right: ($grid-gutter-width / 4);
 -    padding-left: ($grid-gutter-width / 4);
@@ -207,18 +196,18 @@ index c373d46ca..c2ffcfe0a 100644
 +    padding-left: math.div($grid-gutter-width, 4);
    }
  }
- 
+
 diff --git a/packages/server-admin-ui/scss/style.scss b/packages/server-admin-ui/scss/style.scss
 index 0062c7272..f569a7755 100644
 --- a/packages/server-admin-ui/scss/style.scss
 +++ b/packages/server-admin-ui/scss/style.scss
 @@ -10,7 +10,7 @@
  @import 'bootstrap-variables';
- 
+
  // Import Bootstrap source files
 -@import '~bootstrap/scss/bootstrap';
 +@import 'bootstrap/scss/bootstrap';
- 
+
  // Override core variables
  @import 'core-variables';
 diff --git a/packages/server-admin-ui/src/bootstrap.js b/packages/server-admin-ui/src/bootstrap.js
@@ -226,9 +215,9 @@ index fdcc45a3a..0661977c1 100644
 --- a/packages/server-admin-ui/src/bootstrap.js
 +++ b/packages/server-admin-ui/src/bootstrap.js
 @@ -297,9 +297,6 @@ function nameCollator(left, right) {
- 
+
  window.serverRoutesPrefix = '/skServer'
- 
+
 -// eslint-disable-next-line no-undef
 -__webpack_init_sharing__('default')
 -
@@ -242,7 +231,7 @@ index 8637ea582..bda6a192a 100644
 @@ -1,27 +1,137 @@
  import React from 'react'
 +import ReactDOM from 'react-dom'
- 
+
 -export const toLazyDynamicComponent = (moduleName, component) =>
 -  React.lazy(
 -    () =>
@@ -395,7 +384,7 @@ index 8637ea582..bda6a192a 100644
 +      }
 +    })()
    )
- 
+
  export const toSafeModuleId = (moduleName) => moduleName.replace(/[-@/]/g, '_')
 diff --git a/packages/server-admin-ui/vite.config.js b/packages/server-admin-ui/vite.config.js
 new file mode 100644
@@ -472,7 +461,7 @@ diff --git a/src/serverroutes.ts b/src/serverroutes.ts
 index 0e469b6fb..6aed30faf 100644
 --- a/src/serverroutes.ts
 +++ b/src/serverroutes.ts
-@@ -172,10 +172,15 @@ module.exports = function (
+@@ -201,10 +201,15 @@ module.exports = function (
    const logopath = path.resolve(app.config.configPath, 'logo.svg')
    if (fs.existsSync(logopath)) {
      debug(`Found custom logo at ${logopath}, adding route for it`)
@@ -485,10 +474,10 @@ index 0e469b6fb..6aed30faf 100644
 +      '/admin/assets/signal-k-logo-image-text*.svg',
 +      (req: Request, res: Response) => res.sendFile(logopath)
 +    )
- 
+
      // Check for custom logo for minimized sidebar, otherwise use the existing logo.
      const minimizedLogoPath = path.resolve(
-@@ -185,10 +190,15 @@ module.exports = function (
+@@ -214,10 +219,15 @@ module.exports = function (
      const minimizedLogo = fs.existsSync(minimizedLogoPath)
        ? minimizedLogoPath
        : logopath
@@ -502,5 +491,5 @@ index 0e469b6fb..6aed30faf 100644
 +      (req: Request, res: Response) => res.sendFile(minimizedLogo)
 +    )
    }
- 
+
    // mount before the main /admin


### PR DESCRIPTION
Update mdns.patch and webpack-to-vite.patch to be compatible with the latest upstream signalk-server changes:

- mdns.patch: Updated context lines for package.json dependencies section which was restructured with new @assemblyscript/* packages. Updated src/index.ts stop() method line numbers.

- webpack-to-vite.patch: Updated context for .prettierignore and eslint.config.js which now include AssemblyScript-related entries. Updated src/serverroutes.ts line numbers for WASM logging init. Removed root package.json @tsconfig/node20 version bump as upstream already has ^20.1.8.

Both patches now apply cleanly to signalk-server master.