### PR TITLE
Fix DataRow.js.patch to use connect HOC instead of useSelector

### DIFF
--- a/patch_latest/DataRow.js.patch
+++ b/patch_latest/DataRow.js.patch
@@ -1,41 +1,57 @@
---- a/packages/server-admin-ui/src/views/DataBrowser/DataRow.js	2026-01-11 16:00:38.068652018 +0000
-+++ b/packages/server-admin-ui/src/views/DataBrowser/DataRow.js	2026-01-11 16:00:53.983871202 +0000
-@@ -1,4 +1,5 @@
+--- a/packages/server-admin-ui/src/views/DataBrowser/DataRow.js	2026-01-11 16:00:38.000000000 +0000
++++ b/packages/server-admin-ui/src/views/DataBrowser/DataRow.js	2026-01-11 16:10:19.685391598 +0000
+@@ -1,10 +1,27 @@
  import React from 'react'
-+import { useSelector } from 'react-redux'
++import { connect } from 'react-redux'
  import { usePathData, useMetaData } from './usePathData'
  import TimestampCell from './TimestampCell'
  import CopyToClipboardWithFade from './CopyToClipboardWithFade'
-@@ -19,6 +20,23 @@
+ import { getValueRenderer, DefaultValueRenderer } from './ValueRenderers'
+ 
+ /**
++ * Get a display label for a source reference by looking up device descriptions.
++ */
++function getSourceDisplayName(sourceRef, serverStatistics) {
++  const devices = (serverStatistics && serverStatistics.devices) || []
++  if (sourceRef && sourceRef.startsWith('ws.')) {
++    const device = devices.find(
++      (d) =>
++        sourceRef === `ws.${d.clientId}` ||
++        sourceRef.startsWith(`ws.${d.clientId}.`)
++    )
++    if (device && device.description) return device.description
++  }
++  return sourceRef
++}
++
++/**
+  * DataRow - Individual virtualized row with granular subscription
+  * Only re-renders when THIS path's data changes
+  */
+@@ -15,7 +32,8 @@
+   raw,
+   isPaused,
+   onToggleSource,
+-  selectedSources
++  selectedSources,
++  serverStatistics
  }) {
    const data = usePathData(context, path$SourceKey)
    const meta = useMetaData(context, data?.path)
-+  const serverStatistics = useSelector((state) => state.serverStatistics)
-+
-+  /**
-+   * Get a display label for a source reference by looking up device descriptions.
-+   */
-+  const getSourceDisplayName = (sourceRef) => {
-+    const devices = serverStatistics?.devices || []
-+    if (sourceRef && sourceRef.startsWith('ws.')) {
-+      const device = devices.find(
-+        (d) =>
-+          sourceRef === `ws.${d.clientId}` ||
-+          sourceRef.startsWith(`ws.${d.clientId}.`)
-+      )
-+      if (device && device.description) return device.description
-+    }
-+    return sourceRef
-+  }
- 
-   if (!data) {
-     return (
 @@ -65,7 +83,7 @@
            }}
          />
          <CopyToClipboardWithFade text={data.$source}>
 -          {data.$source} <i className="far fa-copy"></i>
-+          {getSourceDisplayName(data.$source)} <i className="far fa-copy"></i>
++          {getSourceDisplayName(data.$source, serverStatistics)} <i className="far fa-copy"></i>
          </CopyToClipboardWithFade>{' '}
          {data.pgn || ''}
          {data.sentence || ''}
+@@ -105,4 +123,6 @@
+   return <DefaultValueRenderer value={data.value} units={units} />
+ }
+ 
+-export default React.memo(DataRow)
++export default connect(({ serverStatistics }) => ({ serverStatistics }))(
++  React.memo(DataRow)
++)


### PR DESCRIPTION
react-redux 5.1.2 doesn't support hooks. Changed from useSelector to the connect HOC pattern for compatibility.