### PR TITLE
Fix DataRow.js.patch to match current upstream file

### DIFF
--- a/patch_latest/DataRow.js.patch
+++ b/patch_latest/DataRow.js.patch
@@ -1,5 +1,5 @@
---- a/packages/server-admin-ui/src/views/DataBrowser/DataRow.js	2026-01-11 16:00:38.000000000 +0000
-+++ b/packages/server-admin-ui/src/views/DataBrowser/DataRow.js	2026-01-11 16:10:19.685391598 +0000
+--- a/packages/server-admin-ui/src/views/DataBrowser/DataRow.js
++++ b/packages/server-admin-ui/src/views/DataBrowser/DataRow.js
 @@ -1,10 +1,27 @@
  import React from 'react'
 +import { connect } from 'react-redux'
@@ -7,7 +7,7 @@
  import TimestampCell from './TimestampCell'
  import CopyToClipboardWithFade from './CopyToClipboardWithFade'
  import { getValueRenderer, DefaultValueRenderer } from './ValueRenderers'
- 
+
  /**
 + * Get a display label for a source reference by looking up device descriptions.
 + */
@@ -38,19 +38,19 @@
  }) {
    const data = usePathData(context, path$SourceKey)
    const meta = useMetaData(context, data?.path)
-@@ -65,7 +83,7 @@
+@@ -73,7 +91,7 @@
            }}
          />
          <CopyToClipboardWithFade text={data.$source}>
 -          {data.$source} <i className="far fa-copy"></i>
 +          {getSourceDisplayName(data.$source, serverStatistics)} <i className="far fa-copy"></i>
-         </CopyToClipboardWithFade>{' '}
-         {data.pgn || ''}
-         {data.sentence || ''}
-@@ -105,4 +123,6 @@
+         </CopyToClipboardWithFade>
+         {data.pgn && <span>&nbsp;{data.pgn}</span>}
+         {data.sentence && <span>&nbsp;{data.sentence}</span>}
+@@ -113,4 +131,6 @@
    return <DefaultValueRenderer value={data.value} units={units} />
  }
- 
+
 -export default React.memo(DataRow)
 +export default connect(({ serverStatistics }) => ({ serverStatistics }))(
 +  React.memo(DataRow)


### PR DESCRIPTION
The patch was failing to apply because the upstream DataRow.js has changed:
- Updated line numbers to match current file structure
- Fixed context lines for $source display (now uses span elements)
- Removed timestamp from patch header for cleaner diffs

https://claude.ai/code/session_01DA7NteJh62PRFXQwMy6WD9