### PR TITLE
Fix NMEA0183 feed timeout handling in pre-release workflow

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Feed NMEA0183 (default port 10110)
         run: |
-          timeout 15 sh -c 'while true; do cat docker/tests/sample.nmea; sleep 1; done | nc localhost 10110'
+          for i in $(seq 1 15); do cat docker/tests/sample.nmea; sleep 1; done | nc -w 5 -q 1 localhost 10110 || true
 
       - name: Validate REST API output
         run: |


### PR DESCRIPTION
## Summary
Updated the NMEA0183 data feed command in the pre-release workflow to improve reliability and error handling.

## Key Changes
- Replaced `timeout 15` with an explicit loop using `seq 1 15` for better control over iteration count
- Added `-w 5 -q 1` flags to `nc` command for improved connection handling (5-second timeout, quit after EOF)
- Added `|| true` to prevent workflow failure if the feed command exits with non-zero status
- Maintains the same 15-second feed duration while being more resilient to transient failures

## Implementation Details
The previous approach used `timeout` with an infinite loop, which could be abruptly terminated. The new approach:
- Explicitly iterates 15 times with 1-second sleep between iterations
- Uses netcat flags to gracefully handle connection closure
- Allows the step to continue even if the feed encounters issues, preventing false negatives in CI/CD

https://claude.ai/code/session_016s7c44Va91m43uk718ZAjw