### PR TITLE
Fix WebSocket subscription, backpressure, and metadata handling bugs

### DIFF
--- a/patch/07-websocket-congestion-backpressure/0001-fix-websocket-congestion-backpressure.patch
+++ b/patch/07-websocket-congestion-backpressure/0001-fix-websocket-congestion-backpressure.patch
@@ -1,0 +1,176 @@
+From e907c1c6ef3dcf28a04e7544f13344ba80d1a6e2 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Sun, 22 Feb 2026 10:57:09 +0000
+Subject: [PATCH] fix: three WebSocket subscription/congestion bugs
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+1. GranularSubscriptionManager.startDiscovery() did not reset
+   currentPaths before re-sending the initial subscribe message.
+   On context switch (handleContextChange calls startDiscovery
+   without first calling unsubscribeAll), the stale currentPaths
+   could satisfy _pathsAreSimilar (≥80% overlap is common when
+   switching between vessels with the same Signal K paths), causing
+   requestPaths to skip the resubscription and leaving the UI with
+   no live data for the new context.
+
+2. Each $backpressure event in actions.js queued a fresh 10-second
+   setTimeout for BACKPRESSURE_WARNING_CLEAR without cancelling the
+   previous one. Under sustained backpressure the timers accumulated,
+   firing redundant state updates long after the warning was already
+   cleared. Track the single active timer and cancel it before
+   rescheduling.
+
+3. The backpressure enter/accumulate check block was copy-pasted
+   verbatim in both the onChange realtime handler and the
+   processSubscribe callback in ws.js. Extract it into a
+   sendOrAccumulate() helper to eliminate the DRY violation.
+
+https://claude.ai/code/session_0142hccyF52oZwDAmLrntwTp
+---
+ packages/server-admin-ui/src/actions.js       | 12 +++-
+ .../GranularSubscriptionManager.js            |  4 ++
+ src/interfaces/ws.js                          | 67 ++++++++-----------
+ 3 files changed, 41 insertions(+), 42 deletions(-)
+
+diff --git a/packages/server-admin-ui/src/actions.js b/packages/server-admin-ui/src/actions.js
+index 586cc78..b82bea7 100644
+--- a/packages/server-admin-ui/src/actions.js
++++ b/packages/server-admin-ui/src/actions.js
+@@ -156,6 +156,10 @@ export function fetchAllData(dispatch) {
+   fetchAccessRequests(dispatch)
+ }
+ 
++// Single timer shared across connections so stale auto-clear dispatches
++// from a previous burst of backpressure events cannot race with newer ones.
++let backpressureClearTimer = null
++
+ export function openServerEventsConnection(dispatch, isReconnect) {
+   const proto = window.location.protocol === 'https:' ? 'wss' : 'ws'
+   const ws = new WebSocket(
+@@ -178,8 +182,12 @@ export function openServerEventsConnection(dispatch, isReconnect) {
+           timestamp: Date.now()
+         }
+       })
+-      // Auto-clear after 10 seconds
+-      setTimeout(() => {
++      // Cancel any pending clear so only the most recent event's timer fires
++      if (backpressureClearTimer) {
++        clearTimeout(backpressureClearTimer)
++      }
++      backpressureClearTimer = setTimeout(() => {
++        backpressureClearTimer = null
+         dispatch({ type: 'BACKPRESSURE_WARNING_CLEAR' })
+       }, 10000)
+     }
+diff --git a/packages/server-admin-ui/src/views/DataBrowser/GranularSubscriptionManager.js b/packages/server-admin-ui/src/views/DataBrowser/GranularSubscriptionManager.js
+index 8aa203e..05122f8 100644
+--- a/packages/server-admin-ui/src/views/DataBrowser/GranularSubscriptionManager.js
++++ b/packages/server-admin-ui/src/views/DataBrowser/GranularSubscriptionManager.js
+@@ -54,6 +54,10 @@ class GranularSubscriptionManager {
+   startDiscovery() {
+     if (!this.webSocket) return
+ 
++    // Reset path tracking so _pathsAreSimilar does not suppress the first
++    // requestPaths call after a context change or reconnect
++    this.currentPaths = new Set()
++
+     log('Starting subscription with announceNewPaths')
+ 
+     // Subscribe with announceNewPaths to discover all paths
+diff --git a/src/interfaces/ws.js b/src/interfaces/ws.js
+index 47992cc..aafe1e9 100644
+--- a/src/interfaces/ws.js
++++ b/src/interfaces/ws.js
+@@ -224,26 +224,7 @@ module.exports = function (app) {
+           )
+           if (!filtered) return
+ 
+-          const bufferSize = spark.request.socket.bufferSize
+-
+-          if (bufferSize > BACKPRESSURE_ENTER_THRESHOLD) {
+-            // Enter/stay in backpressure mode - accumulate latest values only
+-            if (!spark.backpressure.active) {
+-              spark.backpressure.active = true
+-              spark.backpressure.since = Date.now()
+-              debug(
+-                'Entering backpressure mode for spark %s (buffer: %d)',
+-                spark.id,
+-                bufferSize
+-              )
+-            }
+-            accumulateLatestValue(spark.backpressure.accumulator, filtered)
+-          } else {
+-            // Normal mode - send immediately
+-            sendMetaData(app, spark, filtered)
+-            spark.write(filtered)
+-          }
+-
++          sendOrAccumulate(app, spark, filtered)
+           assertBufferSize(spark)
+         }
+ 
+@@ -695,26 +676,7 @@ function processSubscribe(app, unsubscribes, spark, assertBufferSize, msg) {
+         )
+         if (!filtered) return
+ 
+-        const bufferSize = spark.request.socket.bufferSize
+-
+-        if (bufferSize > BACKPRESSURE_ENTER_THRESHOLD) {
+-          // Enter/stay in backpressure mode - accumulate latest values only
+-          if (!spark.backpressure.active) {
+-            spark.backpressure.active = true
+-            spark.backpressure.since = Date.now()
+-            debug(
+-              'Entering backpressure mode for spark %s (buffer: %d)',
+-              spark.id,
+-              bufferSize
+-            )
+-          }
+-          accumulateLatestValue(spark.backpressure.accumulator, filtered)
+-        } else {
+-          // Normal mode - send immediately
+-          sendMetaData(app, spark, filtered)
+-          spark.write(filtered)
+-        }
+-
++        sendOrAccumulate(app, spark, filtered)
+         assertBufferSize(spark)
+       },
+       spark.request.skPrincipal
+@@ -872,6 +834,31 @@ function startServerLog(app, spark) {
+   }
+ }
+ 
++/**
++ * Send a filtered delta to the client, applying backpressure if the socket
++ * buffer is over threshold.  Extracted to avoid duplicating this logic in
++ * both the realtime onChange handler and the subscription callback.
++ */
++function sendOrAccumulate(app, spark, filtered) {
++  const bufferSize = spark.request.socket.bufferSize
++
++  if (bufferSize > BACKPRESSURE_ENTER_THRESHOLD) {
++    if (!spark.backpressure.active) {
++      spark.backpressure.active = true
++      spark.backpressure.since = Date.now()
++      debug(
++        'Entering backpressure mode for spark %s (buffer: %d)',
++        spark.id,
++        bufferSize
++      )
++    }
++    accumulateLatestValue(spark.backpressure.accumulator, filtered)
++  } else {
++    sendMetaData(app, spark, filtered)
++    spark.write(filtered)
++  }
++}
++
+ /**
+  * Flush accumulated values as spec-compliant deltas.
+  * Uses buildFlushDeltas from LatestValuesAccumulator to build the deltas.
+-- 
+2.43.0
+

--- a/patch/08-remove-resubscribe-timeout/0002-fix-remove-resubscribe-timeout.patch
+++ b/patch/08-remove-resubscribe-timeout/0002-fix-remove-resubscribe-timeout.patch
@@ -1,0 +1,111 @@
+From 5103909f76097dad6f83ae9580e7593d86b6f97c Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Sun, 22 Feb 2026 11:59:32 +0000
+Subject: [PATCH] fix: remove unnecessary 10ms delay in DataBrowser
+ resubscription
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The setTimeout(..., 10) between the unsubscribe and subscribe sends
+in _executeResubscription was added to "ensure order", but WebSocket
+is a full-duplex stream protocol that guarantees in-order delivery on
+a single connection. Two consecutive send() calls on the same socket
+will always arrive at the server in the order they were sent, with no
+artificial delay required.
+
+Remove the timeout so state transitions (RESUBSCRIBING → SUBSCRIBED)
+and path tracking happen synchronously, making the code easier to
+reason about.
+
+https://claude.ai/code/session_0142hccyF52oZwDAmLrntwTp
+---
+ .../GranularSubscriptionManager.js            | 67 ++++++++++---------
+ 1 file changed, 34 insertions(+), 33 deletions(-)
+
+diff --git a/packages/server-admin-ui/src/views/DataBrowser/GranularSubscriptionManager.js b/packages/server-admin-ui/src/views/DataBrowser/GranularSubscriptionManager.js
+index 8aa203e..b8f130d 100644
+--- a/packages/server-admin-ui/src/views/DataBrowser/GranularSubscriptionManager.js
++++ b/packages/server-admin-ui/src/views/DataBrowser/GranularSubscriptionManager.js
+@@ -184,44 +184,45 @@ class GranularSubscriptionManager {
+       unsubscribe: [{ path: '*' }]
+     })
+ 
+-    // Step 2: Subscribe to new paths (with small delay to ensure order)
+-    setTimeout(() => {
+-      if (!newPaths || newPaths.size === 0) {
+-        this.currentPaths = new Set()
+-        this.state = STATE.SUBSCRIBED
+-        return
+-      }
++    // Step 2: Subscribe to new paths.
++    // WebSocket guarantees in-order delivery on a single connection, so the
++    // subscribe message sent right after the unsubscribe will always be
++    // processed by the server in the correct sequence.
++    if (!newPaths || newPaths.size === 0) {
++      this.currentPaths = new Set()
++      this.state = STATE.SUBSCRIBED
++      return
++    }
+ 
+-      // Extract unique paths (remove source suffix from path$SourceKeys)
+-      const uniquePaths = this._extractUniquePaths(newPaths)
++    // Extract unique paths (remove source suffix from path$SourceKeys)
++    const uniquePaths = this._extractUniquePaths(newPaths)
+ 
+-      if (uniquePaths.length === 0) {
+-        this.currentPaths = new Set()
+-        this.state = STATE.SUBSCRIBED
+-        return
+-      }
++    if (uniquePaths.length === 0) {
++      this.currentPaths = new Set()
++      this.state = STATE.SUBSCRIBED
++      return
++    }
+ 
+-      const subMsg = {
+-        context: '*',
+-        announceNewPaths: true, // Continue discovering new paths
+-        subscribe: uniquePaths.map((path) => ({ path }))
+-      }
++    const subMsg = {
++      context: '*',
++      announceNewPaths: true, // Continue discovering new paths
++      subscribe: uniquePaths.map((path) => ({ path }))
++    }
+ 
+-      this._send(subMsg)
+-      this.currentPaths = newPaths
+-      this.state = STATE.SUBSCRIBED
++    this._send(subMsg)
++    this.currentPaths = newPaths
++    this.state = STATE.SUBSCRIBED
+ 
+-      // Check if there's a pending request that came in during resubscription
+-      if (this.pendingPaths) {
+-        const pending = this.pendingPaths
+-        this.pendingPaths = null
+-        // Debounce the pending request
+-        this.debounceTimer = setTimeout(() => {
+-          this.debounceTimer = null
+-          this._executeResubscription(pending)
+-        }, this.DEBOUNCE_MS)
+-      }
+-    }, 10)
++    // Check if there's a pending request that came in during resubscription
++    if (this.pendingPaths) {
++      const pending = this.pendingPaths
++      this.pendingPaths = null
++      // Debounce the pending request
++      this.debounceTimer = setTimeout(() => {
++        this.debounceTimer = null
++        this._executeResubscription(pending)
++      }, this.DEBOUNCE_MS)
++    }
+   }
+ 
+   /**
+-- 
+2.43.0
+

--- a/patch/09-valueemitting-store-eviction/0003-fix-valueemitting-store-eviction.patch
+++ b/patch/09-valueemitting-store-eviction/0003-fix-valueemitting-store-eviction.patch
@@ -1,0 +1,108 @@
+From 14a28034aaa7708c97474c197fbcd110c008531a Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Sun, 22 Feb 2026 12:01:07 +0000
+Subject: [PATCH] fix: evict stale AIS contexts from ValueEmittingStore to
+ bound memory
+
+ValueEmittingStore is a singleton that accumulates data for every
+context seen in a session (vessels.self, plus every AIS target).
+In a busy anchorage or port with hundreds of AIS targets, the store
+grows without limit over a long session because it had no eviction.
+
+Track the last-updated timestamp for each non-self context and
+schedule a periodic sweep (every 5 minutes, matching the server-side
+deltacache.ts purge interval) that removes contexts not updated within
+that window. Eviction also cleans up the per-path listeners map so
+there are no dangling callbacks.
+
+If the user is browsing an evicted context it will briefly show
+"waiting for data" until the next server delta repopulates it.
+
+https://claude.ai/code/session_0142hccyF52oZwDAmLrntwTp
+---
+ .../views/DataBrowser/ValueEmittingStore.js   | 49 +++++++++++++++++++
+ 1 file changed, 49 insertions(+)
+
+diff --git a/packages/server-admin-ui/src/views/DataBrowser/ValueEmittingStore.js b/packages/server-admin-ui/src/views/DataBrowser/ValueEmittingStore.js
+index 426be40..795fc00 100644
+--- a/packages/server-admin-ui/src/views/DataBrowser/ValueEmittingStore.js
++++ b/packages/server-admin-ui/src/views/DataBrowser/ValueEmittingStore.js
+@@ -8,6 +8,10 @@
+  * since the same path can have multiple values from different sources.
+  */
+ 
++// Evict non-self contexts that have not received an update in this window.
++// Mirrors the server-side deltacache.ts AIS purge cycle.
++const CONTEXT_EVICTION_MAX_AGE_MS = 5 * 60 * 1000
++
+ class ValueEmittingStore {
+   constructor() {
+     // Data storage: { context: { path$SourceKey: pathData } }
+@@ -20,6 +24,39 @@ class ValueEmittingStore {
+     this.structureListeners = new Set()
+     // Version counter for structural changes
+     this.version = 0
++    // Last-updated timestamps for non-self contexts (used for eviction)
++    this._contextLastUpdated = {}
++  }
++
++  /**
++   * Evict a single context - removes all stored data, meta, and listeners.
++   * Structure listeners are notified so the UI can update.
++   */
++  _evictContext(context) {
++    const paths = Object.keys(this.data[context] || {})
++    for (const path$SourceKey of paths) {
++      this.listeners.delete(`${context}:${path$SourceKey}`)
++    }
++    delete this.data[context]
++    delete this.meta[context]
++    delete this._contextLastUpdated[context]
++    this.version++
++    this.structureListeners.forEach((callback) => callback(this.version))
++  }
++
++  /**
++   * Evict non-self contexts that have not received an update within maxAgeMs.
++   * Called periodically by the singleton instance.
++   */
++  _evictStaleContexts(maxAgeMs) {
++    const now = Date.now()
++    for (const context of Object.keys(this.data)) {
++      if (context === 'self') continue
++      const lastUpdated = this._contextLastUpdated[context] || 0
++      if (now - lastUpdated > maxAgeMs) {
++        this._evictContext(context)
++      }
++    }
+   }
+ 
+   /**
+@@ -30,6 +67,11 @@ class ValueEmittingStore {
+       this.data[context] = {}
+     }
+ 
++    // Track last-update time so _evictStaleContexts knows which contexts are live
++    if (context !== 'self') {
++      this._contextLastUpdated[context] = Date.now()
++    }
++
+     const isNew = !this.data[context][path$SourceKey]
+     this.data[context][path$SourceKey] = pathData
+ 
+@@ -118,5 +160,12 @@ class ValueEmittingStore {
+ // Singleton instance
+ const store = new ValueEmittingStore()
+ 
++// Periodically remove stale non-self contexts to prevent unbounded memory growth
++// from AIS targets that are no longer transmitting.
++setInterval(
++  () => store._evictStaleContexts(CONTEXT_EVICTION_MAX_AGE_MS),
++  CONTEXT_EVICTION_MAX_AGE_MS
++)
++
+ export default store
+ export { ValueEmittingStore }
+-- 
+2.43.0
+

--- a/patch/10-usemetadata-subscription/0004-fix-usemetadata-subscription.patch
+++ b/patch/10-usemetadata-subscription/0004-fix-usemetadata-subscription.patch
@@ -1,0 +1,113 @@
+From e540864da5fc661332a3915b62f8b970a21b60f5 Mon Sep 17 00:00:00 2001
+From: Claude <noreply@anthropic.com>
+Date: Sun, 22 Feb 2026 12:02:20 +0000
+Subject: [PATCH] fix: useMetaData hook does not react to metadata updates
+
+useMetaData only read from the store once (on mount and on
+context/path changes) but never subscribed to subsequent meta
+updates. Any metadata arriving after initial render was silently
+ignored, leaving the displayed meta stale for the lifetime of the
+component.
+
+Add subscribeMeta(context, path, callback) to ValueEmittingStore,
+mirroring the existing subscribe() method for path values. Call it
+from updateMeta() to notify listeners. Wire useMetaData up to the
+new subscription so it re-renders whenever the server sends updated
+metadata for the watched path.
+
+https://claude.ai/code/session_0142hccyF52oZwDAmLrntwTp
+---
+ .../views/DataBrowser/ValueEmittingStore.js   | 32 ++++++++++++++++++-
+ .../src/views/DataBrowser/usePathData.js      |  7 +++-
+ 2 files changed, 37 insertions(+), 2 deletions(-)
+
+diff --git a/packages/server-admin-ui/src/views/DataBrowser/ValueEmittingStore.js b/packages/server-admin-ui/src/views/DataBrowser/ValueEmittingStore.js
+index 426be40..e6bd5cb 100644
+--- a/packages/server-admin-ui/src/views/DataBrowser/ValueEmittingStore.js
++++ b/packages/server-admin-ui/src/views/DataBrowser/ValueEmittingStore.js
+@@ -16,6 +16,8 @@ class ValueEmittingStore {
+     this.meta = {}
+     // Per-path listeners: Map<"context:path$SourceKey", Set<callback>>
+     this.listeners = new Map()
++    // Per-path meta listeners: Map<"meta:context:path", Set<callback>>
++    this.metaListeners = new Map()
+     // Listeners for structural changes (new paths added)
+     this.structureListeners = new Set()
+     // Version counter for structural changes
+@@ -48,13 +50,20 @@ class ValueEmittingStore {
+   }
+ 
+   /**
+-   * Update metadata for a path
++   * Update metadata for a path and notify subscribers
+    */
+   updateMeta(context, path, metaData) {
+     if (!this.meta[context]) {
+       this.meta[context] = {}
+     }
+     this.meta[context][path] = { ...this.meta[context][path], ...metaData }
++
++    // Notify meta-specific listeners
++    const key = `meta:${context}:${path}`
++    const listeners = this.metaListeners.get(key)
++    if (listeners) {
++      listeners.forEach((callback) => callback(this.meta[context][path]))
++    }
+   }
+ 
+   /**
+@@ -106,6 +115,27 @@ class ValueEmittingStore {
+     }
+   }
+ 
++  /**
++   * Subscribe to metadata updates for a path - returns unsubscribe function
++   */
++  subscribeMeta(context, path, callback) {
++    const key = `meta:${context}:${path}`
++    if (!this.metaListeners.has(key)) {
++      this.metaListeners.set(key, new Set())
++    }
++    this.metaListeners.get(key).add(callback)
++
++    return () => {
++      const listeners = this.metaListeners.get(key)
++      if (listeners) {
++        listeners.delete(callback)
++        if (listeners.size === 0) {
++          this.metaListeners.delete(key)
++        }
++      }
++    }
++  }
++
+   /**
+    * Subscribe to structural changes (new paths added)
+    */
+diff --git a/packages/server-admin-ui/src/views/DataBrowser/usePathData.js b/packages/server-admin-ui/src/views/DataBrowser/usePathData.js
+index 20fe1cb..9e0bf16 100644
+--- a/packages/server-admin-ui/src/views/DataBrowser/usePathData.js
++++ b/packages/server-admin-ui/src/views/DataBrowser/usePathData.js
+@@ -59,13 +59,18 @@ export function usePathData(context, path$SourceKey) {
+ }
+ 
+ /**
+- * Hook to get metadata for a path
++ * Hook to get metadata for a path, updating whenever new meta arrives
+  */
+ export function useMetaData(context, path) {
+   const [meta, setMeta] = useState(() => store.getMeta(context, path))
+ 
+   useEffect(() => {
++    // Sync with current value when context or path changes
+     setMeta(store.getMeta(context, path))
++
++    // Subscribe to future meta updates for this path
++    const unsubscribe = store.subscribeMeta(context, path, setMeta)
++    return unsubscribe
+   }, [context, path])
+ 
+   return meta
+-- 
+2.43.0
+


### PR DESCRIPTION
This PR addresses four critical issues affecting real-time data delivery and UI responsiveness in the DataBrowser:

## Summary
Fixes WebSocket subscription state management, backpressure event handling, metadata reactivity, and memory growth from stale AIS contexts. Also removes an unnecessary delay in subscription reordering.

## Key Changes

1. **WebSocket Subscription State Bug** (`GranularSubscriptionManager.js`)
   - Reset `currentPaths` in `startDiscovery()` to prevent stale path data from suppressing resubscription after context switches
   - Without this fix, switching between vessels with similar Signal K paths would leave the UI with no live data because the path similarity check would skip resubscription

2. **Backpressure Timer Accumulation** (`actions.js`)
   - Track a single active backpressure clear timer instead of queuing multiple timers per event
   - Cancel the previous timer before scheduling a new one to prevent redundant state updates firing long after backpressure clears
   - Fixes race conditions under sustained backpressure

3. **Backpressure Logic Duplication** (`ws.js`)
   - Extract the buffer check and send-or-accumulate logic into a `sendOrAccumulate()` helper function
   - Eliminates DRY violation where identical backpressure handling was copy-pasted in two locations (realtime onChange handler and subscription callback)

4. **Metadata Subscription Reactivity** (`ValueEmittingStore.js`, `usePathData.js`)
   - Add `subscribeMeta()` method to `ValueEmittingStore` mirroring the existing `subscribe()` for path values
   - Wire `useMetaData` hook to subscribe to metadata updates so it re-renders when new metadata arrives
   - Previously metadata was only read once on mount, leaving displayed metadata stale for the component lifetime

5. **Memory Growth from Stale AIS Contexts** (`ValueEmittingStore.js`)
   - Implement periodic eviction of non-self contexts not updated within 5 minutes (matching server-side deltacache purge interval)
   - Track last-updated timestamps and clean up associated listeners to prevent unbounded memory growth in long sessions with many AIS targets

6. **Unnecessary Resubscription Delay** (`GranularSubscriptionManager.js`)
   - Remove the 10ms `setTimeout` between unsubscribe and subscribe messages
   - WebSocket guarantees in-order delivery on a single connection, making the artificial delay unnecessary and simplifying state transitions

## Implementation Details
- Backpressure timer tracking uses module-level variable to ensure single active timer across all connections
- Context eviction runs every 5 minutes with configurable max age threshold
- Meta subscription uses the same listener pattern as path subscriptions for consistency
- All changes maintain backward compatibility with existing subscription and data flow logic

https://claude.ai/code/session_01S6CM4aMuaJpS8PAJUiFcfF