### PR TITLE
Replace mdns-js with dnssd2 for mDNS discovery and responder

### DIFF
--- a/patch/04-dnssd2/xx-dnssd2.patch
+++ b/patch/04-dnssd2/xx-dnssd2.patch
@@ -11,7 +11,7 @@ index 4181677..c7ce98c 100644
      "moment": "^2.10.6",
      "morgan": "^1.5.0",
 diff --git a/src/discovery.js b/src/discovery.js
-index cd3631d..cdf0d33 100644
+index 5da0aee..cdf0d33 100644
 --- a/src/discovery.js
 +++ b/src/discovery.js
 @@ -18,7 +18,7 @@ import { createDebug } from './debug'
@@ -21,16 +21,16 @@ index cd3631d..cdf0d33 100644
 -const mdns = require('mdns-js')
 +const dnssd = require('dnssd2')
  const { networkInterfaces } = require('os')
- 
+
  module.exports.runDiscovery = function (app) {
 @@ -196,28 +196,23 @@ module.exports.runDiscovery = function (app) {
- 
+
    function discoverSignalkWs(wsType) {
      try {
 -      mdns.excludeInterface('0.0.0.0')
 -      var browser = mdns.createBrowser(mdns.tcp('signalk-' + wsType))
 +      const browser = new dnssd.Browser(dnssd.tcp('signalk-' + wsType))
- 
+
 -      browser.on('ready', function onReady() {
 -        try {
 -          debug('looking for SignalK ' + wsType)
@@ -59,29 +59,33 @@ index cd3631d..cdf0d33 100644
 +            )
            ) {
 -            debug('discoverSignalkWs found data[' + wsType + ']:', data)
--            const providerId = `${wsType}-${data.host}:${data.port} (${data.addresses[0]})`
+-            const providerId = wsType + '-' + data.host + ':' + data.port
 +            debug('discoverSignalkWs found service[' + wsType + ']:', service)
 +            const providerId = `${wsType}-${service.host}:${service.port} (${service.addresses[0]})`
              app.emit('discovered', {
                id: providerId,
                enabled: false,
-@@ -228,9 +223,9 @@ module.exports.runDiscovery = function (app) {
+@@ -228,11 +223,12 @@ module.exports.runDiscovery = function (app) {
                      type: 'SignalK',
                      subOptions: {
                        type: wsType,
 -                      host: data.host,
 -                      port: data.port,
--                      address: data.addresses[0],
+-                      providerId: providerId
 +                      host: service.host,
 +                      port: service.port,
 +                      address: service.addresses[0],
-                       providerId
++                      providerId
                      },
-                     providerId
-@@ -244,6 +239,13 @@ module.exports.runDiscovery = function (app) {
+-                    providerId: providerId
++                    providerId
+                   }
+                 }
+               ]
+@@ -243,6 +239,13 @@ module.exports.runDiscovery = function (app) {
          }
        })
- 
+
 +      browser.on('error', (err) => {
 +        debug('discoverSignalkWs browser error:', err)
 +      })
@@ -99,7 +103,7 @@ index 3d366b6..2c3ca80 100644
 @@ -25,16 +25,6 @@ const ports = require('./ports')
  module.exports = function mdnsResponder(app) {
    const config = app.config
- 
+
 -  let mdns = dnssd
 -
 -  try {
@@ -114,14 +118,14 @@ index 3d366b6..2c3ca80 100644
      debug('Mdns disabled by configuration')
      return
 @@ -57,7 +47,7 @@ module.exports = function mdnsResponder(app) {
- 
+
    const types = []
    types.push({
 -    type: app.config.settings.ssl ? mdns.tcp('https') : mdns.tcp('http'),
 +    type: app.config.settings.ssl ? dnssd.tcp('https') : dnssd.tcp('http'),
      port: ports.getExternalPort(app)
    })
- 
+
 @@ -73,7 +63,7 @@ module.exports = function mdnsResponder(app) {
          service.name.charAt(0) === '_'
        ) {


### PR DESCRIPTION
## Summary
This PR migrates the mDNS implementation from the `mdns-js` library to `dnssd2`, updating both the service discovery and responder functionality.

## Key Changes
- **Discovery module (`src/discovery.js`)**:
  - Replaced `mdns` require with `dnssd2`
  - Updated browser creation from `mdns.createBrowser()` to `new dnssd.Browser()`
  - Changed event handling from `mdns` callback style to `dnssd2` event emitter pattern
  - Updated service object property access from `data.*` to `service.*` (e.g., `data.host` → `service.host`)
  - Improved providerId formatting to use template literals with address information
  - Added error event handler for the browser instance
  - Removed `mdns.excludeInterface()` call (not needed with dnssd2)

- **Responder module (`src/mdnsResponder.js`)**:
  - Removed conditional mdns library loading logic
  - Replaced all `mdns` references with `dnssd` for TCP service type definitions
  - Simplified initialization by removing try-catch wrapper for mdns setup

## Implementation Details
- The migration maintains the same functional behavior while adapting to dnssd2's API
- Service discovery now uses the `dnssd.Browser` class with event-based callbacks
- The providerId now includes the service address for better identification
- Error handling is improved with explicit error event listeners

https://claude.ai/code/session_018uH67jWV3Crpk5ixX3Sddy