### PR TITLE
Remove mdns-js dependency

### DIFF
--- a/patch/04-dnssd2/xx-dnssd2.patch
+++ b/patch/04-dnssd2/xx-dnssd2.patch
@@ -2,8 +2,7 @@ diff --git a/package.json b/package.json
 index 4181677..c7ce98c 100644
 --- a/package.json
 +++ b/package.json
-@@ -118,7 +118,6 @@
-     "listr": "^0.14.1",
+@@ -112,6 +112,5 @@
      "lodash": "^4.17.21",
      "mathjs": "^12.4.0",
 -    "mdns-js": "^1.0.3",


### PR DESCRIPTION
This PR removes the `mdns-js` dependency from the project.

## Summary
The `mdns-js` package (version ^1.0.3) has been removed from package.json dependencies.

## Changes
- Removed `mdns-js` from the project dependencies

## Notes
This change suggests that either:
- The mDNS/DNS-SD functionality is no longer needed
- An alternative implementation or dependency is being used instead
- The functionality has been integrated or replaced elsewhere in the codebase

Please verify that any code relying on `mdns-js` has been updated or replaced accordingly.

https://claude.ai/code/session_01RsV4sg5No2mUteRSUuhjz7