### PR TITLE
Add security config and login rate limiting to WebSocket interface

### DIFF
--- a/patch/01-device-labels/wsNames.patch
+++ b/patch/01-device-labels/wsNames.patch
@@ -340,7 +340,7 @@ diff --git a/src/interfaces/ws.ts b/src/interfaces/ws.ts
 index e0f7608..4f4b4ac 100644
 --- a/src/interfaces/ws.ts
 +++ b/src/interfaces/ws.ts
-@@ -22,7 +22,8 @@ import { getSourceId, getMetadata } from '@signalk/signalk-schema'
+@@ -22,11 +22,12 @@ import { getSourceId, getMetadata } from '@signalk/signalk-schema'
  import {
    requestAccess,
    InvalidTokenError,
@@ -348,6 +348,10 @@ index e0f7608..4f4b4ac 100644
 +  WithSecurityStrategy,
 +  getSecurityConfig
  } from '../security'
+ import {
+   LoginRateLimiter,
+   LOGIN_RATE_LIMIT_MESSAGE
+ } from '../login-rate-limiter'
  import { WithConfig } from '../app'
  import {
 @@ -50,6 +51,98 @@ import { Delta, hasValues } from '@signalk/server-api'


### PR DESCRIPTION
## Summary
This change enhances the WebSocket interface with improved security features by adding login rate limiting and security configuration imports.

## Key Changes
- Added `getSecurityConfig` import from the security module to enable security configuration access
- Added imports for `LoginRateLimiter` and `LOGIN_RATE_LIMIT_MESSAGE` from a new login-rate-limiter module
- These imports enable the WebSocket interface to enforce rate limiting on login attempts and access security configurations

## Implementation Details
The changes prepare the WebSocket interface (`src/interfaces/ws.ts`) to support:
- Rate limiting for login attempts to prevent brute force attacks
- Access to security configuration for enhanced authentication handling
- Integration with a dedicated login rate limiter module for centralized rate limit management

These are foundational imports that will be utilized by subsequent logic in the WebSocket interface implementation.

https://claude.ai/code/session_016qEsxgya1sThRL3PSrJLvj