### PR TITLE
Remove explicit GID assignments from Docker group creation

### DIFF
--- a/docker/Dockerfile_base_26.04_user
+++ b/docker/Dockerfile_base_26.04_user
@@ -12,9 +12,9 @@ RUN apt-get update \
   && apt-get -y install --no-install-recommends apt-utils sudo git \
   python3 python3-venv python3-pip build-essential avahi-daemon libnss-mdns \
   sysstat procps nano curl libcap2-bin dbus bluez \
-  && groupadd -r docker -g 991 \
-  && groupadd -r i2c -g 990 \
-  && groupadd -r spi -g 989 \
+  && groupadd -r docker \
+  && groupadd -r i2c \
+  && groupadd -r spi \
   && usermod -a -G dialout,i2c,spi,netdev,docker node \
   && echo 'node ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
   && chmod u+s /usr/bin/date \


### PR DESCRIPTION
## Summary
Removed explicit GID (group ID) assignments from the Docker group creation commands in the base Dockerfile, allowing the system to automatically assign group IDs instead.

## Changes
- Removed `-g 991` flag from `docker` group creation
- Removed `-g 990` flag from `i2c` group creation
- Removed `-g 989` flag from `spi` group creation

## Details
By removing the explicit GID specifications, the system will automatically assign the next available GID to each group. This approach provides better flexibility and reduces the risk of GID conflicts across different environments and systems where the Docker image may be deployed.

https://claude.ai/code/session_01FkFfnAxxHHdr9CzDbYhonu