### PR TITLE
Add Ubuntu 26.04 support to Docker build workflow

### DIFF
--- a/.github/workflows/build sk docker container all.yml
+++ b/.github/workflows/build sk docker container all.yml
@@ -162,10 +162,10 @@ jobs:
             fi
             if [[ "${{ github.event.inputs.build_ubuntu_2604 }}" == "true" ]]; then
               if [[ "${{ github.event.inputs.build_node_22 }}" == "true" ]]; then
-                echo "ubuntu_26_22=$(generate_tags 'ubuntu26' '22.x')" >> $GITHUB_OUTPUT
+                echo "ubuntu_26_22=$(generate_tags 'ubuntu-26.04' '22.x')" >> $GITHUB_OUTPUT
               fi
               if [[ "${{ github.event.inputs.build_node_24 }}" == "true" ]]; then
-                echo "ubuntu_26_24=$(generate_tags 'ubuntu26' '24.x')" >> $GITHUB_OUTPUT
+                echo "ubuntu_26_24=$(generate_tags 'ubuntu-26.04' '24.x')" >> $GITHUB_OUTPUT
               fi
             fi
           fi
@@ -233,14 +233,14 @@ jobs:
           - vm: ubuntu-latest
             arch: amd64
             os: '26.04'
-            os_label: ubuntu26
+            os_label: ubuntu-26.04
             node: '22.x'
             platform: linux/amd64
             enabled: ${{ github.event.inputs.build_node_22 }}
           - vm: ubuntu-latest
             arch: amd64
             os: '26.04'
-            os_label: ubuntu26
+            os_label: ubuntu-26.04
             node: '24.x'
             platform: linux/amd64
             enabled: ${{ github.event.inputs.build_node_24 }}
@@ -248,14 +248,14 @@ jobs:
           - vm: ubuntu-24.04-arm
             arch: arm64
             os: '26.04'
-            os_label: ubuntu26
+            os_label: ubuntu-26.04
             node: '22.x'
             platform: linux/arm64,linux/arm/v7
             enabled: ${{ github.event.inputs.build_node_22 }}
           - vm: ubuntu-24.04-arm
             arch: arm64
             os: '26.04'
-            os_label: ubuntu26
+            os_label: ubuntu-26.04
             node: '24.x'
             platform: linux/arm64
             enabled: ${{ github.event.inputs.build_node_24 }}
@@ -266,7 +266,7 @@ jobs:
         run: |
           node_enabled="${{ matrix.enabled }}"
           ubuntu26_enabled="true"
-          if [[ "${{ matrix.os_label }}" == "ubuntu26" ]]; then
+          if [[ "${{ matrix.os_label }}" == "ubuntu-26.04" ]]; then
             ubuntu26_enabled="${{ github.event.inputs.build_ubuntu_2604 }}"
           fi
           if [[ "$node_enabled" != "true" || "$ubuntu26_enabled" != "true" ]]; then
@@ -478,14 +478,14 @@ jobs:
             short_tag2: latest-22.x
             enabled: ${{ github.event.inputs.build_node_22 }}
           - node: '24.x'
-            os_label: ubuntu26
-            short_tag: latest-ubuntu26
-            short_tag2: latest-ubuntu26-24.x
+            os_label: ubuntu-26.04
+            short_tag: latest-ubuntu-26.04
+            short_tag2: latest-ubuntu-26.04-24.x
             enabled: ${{ github.event.inputs.build_node_24 }}
           - node: '22.x'
-            os_label: ubuntu26
-            short_tag: latest-ubuntu26-22.x
-            short_tag2: latest-ubuntu26-22.x
+            os_label: ubuntu-26.04
+            short_tag: latest-ubuntu-26.04-22.x
+            short_tag2: latest-ubuntu-26.04-22.x
             enabled: ${{ github.event.inputs.build_node_22 }}
     steps:
       - name: Check if build is enabled
@@ -493,7 +493,7 @@ jobs:
         run: |
           node_enabled="${{ matrix.enabled }}"
           ubuntu26_enabled="true"
-          if [[ "${{ matrix.os_label }}" == "ubuntu26" ]]; then
+          if [[ "${{ matrix.os_label }}" == "ubuntu-26.04" ]]; then
             ubuntu26_enabled="${{ github.event.inputs.build_ubuntu_2604 }}"
           fi
           if [[ "$node_enabled" != "true" || "$ubuntu26_enabled" != "true" ]]; then
@@ -518,7 +518,7 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         id: ghcr_tags
         run: |
-          if [[ "${{ matrix.os_label }}" == "ubuntu26" ]]; then
+          if [[ "${{ matrix.os_label }}" == "ubuntu-26.04" ]]; then
             if [[ "${{ matrix.node }}" == "24.x" ]]; then
               TAGS="${{ needs.generate-tags.outputs.ubuntu_26_24 }}"
             else
@@ -773,14 +773,14 @@ jobs:
             short_tag: latest
             tags_output: ubuntu_24
             enabled: ${{ github.event.inputs.build_docker_tags_ubuntu == 'true' && github.event.inputs.build_node_24 == 'true' }}
-          - os: ubuntu26
+          - os: ubuntu-26.04
             node: '22.x'
-            short_tag: latest-ubuntu26-22.x
+            short_tag: latest-ubuntu-26.04-22.x
             tags_output: ubuntu_26_22
             enabled: ${{ github.event.inputs.build_docker_tags_ubuntu == 'true' && github.event.inputs.build_ubuntu_2604 == 'true' && github.event.inputs.build_node_22 == 'true' }}
-          - os: ubuntu26
+          - os: ubuntu-26.04
             node: '24.x'
-            short_tag: latest-ubuntu26
+            short_tag: latest-ubuntu-26.04
             tags_output: ubuntu_26_24
             enabled: ${{ github.event.inputs.build_docker_tags_ubuntu == 'true' && github.event.inputs.build_ubuntu_2604 == 'true' && github.event.inputs.build_node_24 == 'true' }}
           - os: alpine

--- a/.github/workflows/build sk docker container all.yml
+++ b/.github/workflows/build sk docker container all.yml
@@ -15,6 +15,10 @@ on:
         description: 'Build Debian docker image'
         type: boolean
         default: false
+      build_ubuntu_2604:
+        description: 'Build Ubuntu 26.04 docker image'
+        type: boolean
+        default: false
       build_node_22:
         description: 'Build Node.js 22 images'
         type: boolean
@@ -107,6 +111,8 @@ jobs:
     outputs:
       ubuntu_22: ${{ steps.tags.outputs.ubuntu_22 }}
       ubuntu_24: ${{ steps.tags.outputs.ubuntu_24 }}
+      ubuntu_26_22: ${{ steps.tags.outputs.ubuntu_26_22 }}
+      ubuntu_26_24: ${{ steps.tags.outputs.ubuntu_26_24 }}
       alpine_22: ${{ steps.tags.outputs.alpine_22 }}
       alpine_24: ${{ steps.tags.outputs.alpine_24 }}
       debian_22: ${{ steps.tags.outputs.debian_22 }}
@@ -154,8 +160,16 @@ jobs:
             if [[ "${{ github.event.inputs.build_node_24 }}" == "true" ]]; then
               echo "ubuntu_24=$(generate_tags 'ubuntu' '24.x')" >> $GITHUB_OUTPUT
             fi
+            if [[ "${{ github.event.inputs.build_ubuntu_2604 }}" == "true" ]]; then
+              if [[ "${{ github.event.inputs.build_node_22 }}" == "true" ]]; then
+                echo "ubuntu_26_22=$(generate_tags 'ubuntu26' '22.x')" >> $GITHUB_OUTPUT
+              fi
+              if [[ "${{ github.event.inputs.build_node_24 }}" == "true" ]]; then
+                echo "ubuntu_26_24=$(generate_tags 'ubuntu26' '24.x')" >> $GITHUB_OUTPUT
+              fi
+            fi
           fi
-          
+
           if [[ "${{ github.event.inputs.build_docker_tags_alpine }}" == "true" ]]; then
             if [[ "${{ github.event.inputs.build_node_22 }}" == "true" ]]; then
               echo "alpine_22=$(generate_tags 'alpine' '22')" >> $GITHUB_OUTPUT
@@ -185,25 +199,63 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # AMD64 builds for both node versions
+          # Ubuntu 24.04 AMD64 builds
           - vm: ubuntu-latest
             arch: amd64
+            os: '24.04'
+            os_label: ubuntu
             node: '22.x'
             platform: linux/amd64
             enabled: ${{ github.event.inputs.build_node_22 }}
           - vm: ubuntu-latest
             arch: amd64
+            os: '24.04'
+            os_label: ubuntu
             node: '24.x'
             platform: linux/amd64
             enabled: ${{ github.event.inputs.build_node_24 }}
-          # ARM builds (22.x supports armv7, 24.x only arm64)
+          # Ubuntu 24.04 ARM builds (22.x supports armv7, 24.x only arm64)
           - vm: ubuntu-24.04-arm
             arch: arm64
+            os: '24.04'
+            os_label: ubuntu
             node: '22.x'
             platform: linux/arm64,linux/arm/v7
             enabled: ${{ github.event.inputs.build_node_22 }}
           - vm: ubuntu-24.04-arm
             arch: arm64
+            os: '24.04'
+            os_label: ubuntu
+            node: '24.x'
+            platform: linux/arm64
+            enabled: ${{ github.event.inputs.build_node_24 }}
+          # Ubuntu 26.04 AMD64 builds
+          - vm: ubuntu-latest
+            arch: amd64
+            os: '26.04'
+            os_label: ubuntu26
+            node: '22.x'
+            platform: linux/amd64
+            enabled: ${{ github.event.inputs.build_node_22 }}
+          - vm: ubuntu-latest
+            arch: amd64
+            os: '26.04'
+            os_label: ubuntu26
+            node: '24.x'
+            platform: linux/amd64
+            enabled: ${{ github.event.inputs.build_node_24 }}
+          # Ubuntu 26.04 ARM builds (22.x supports armv7, 24.x only arm64)
+          - vm: ubuntu-24.04-arm
+            arch: arm64
+            os: '26.04'
+            os_label: ubuntu26
+            node: '22.x'
+            platform: linux/arm64,linux/arm/v7
+            enabled: ${{ github.event.inputs.build_node_22 }}
+          - vm: ubuntu-24.04-arm
+            arch: arm64
+            os: '26.04'
+            os_label: ubuntu26
             node: '24.x'
             platform: linux/arm64
             enabled: ${{ github.event.inputs.build_node_24 }}
@@ -212,7 +264,12 @@ jobs:
       - name: Check if build is enabled
         id: check
         run: |
-          if [[ "${{ matrix.enabled }}" != "true" ]]; then
+          node_enabled="${{ matrix.enabled }}"
+          ubuntu26_enabled="true"
+          if [[ "${{ matrix.os_label }}" == "ubuntu26" ]]; then
+            ubuntu26_enabled="${{ github.event.inputs.build_ubuntu_2604 }}"
+          fi
+          if [[ "$node_enabled" != "true" || "$ubuntu26_enabled" != "true" ]]; then
             echo "skip=true" >> $GITHUB_OUTPUT
           else
             echo "skip=false" >> $GITHUB_OUTPUT
@@ -245,9 +302,9 @@ jobs:
           provenance: true
           sbom: true
           tags: |
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:${{ matrix.arch }}-ubuntu-${{ matrix.node }}-${{ github.sha }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:${{ matrix.arch }}-${{ matrix.os_label }}-${{ matrix.node }}-${{ github.sha }}
           build-args: |
-            BASE_IMAGE=24.04-${{ matrix.node }}
+            BASE_IMAGE=${{ matrix.os }}-${{ matrix.node }}
 
   build-alpine-images:
     name: Build Alpine image
@@ -409,21 +466,37 @@ jobs:
       packages: write  # Required for GITHUB_TOKEN to push to GHCR
     strategy:
       matrix:
-        node: ['22.x', '24.x']
         include:
           - node: '24.x'
+            os_label: ubuntu
             short_tag: latest
             short_tag2: latest-24.x
             enabled: ${{ github.event.inputs.build_node_24 }}
           - node: '22.x'
+            os_label: ubuntu
             short_tag: latest-22.x
             short_tag2: latest-22.x
+            enabled: ${{ github.event.inputs.build_node_22 }}
+          - node: '24.x'
+            os_label: ubuntu26
+            short_tag: latest-ubuntu26
+            short_tag2: latest-ubuntu26-24.x
+            enabled: ${{ github.event.inputs.build_node_24 }}
+          - node: '22.x'
+            os_label: ubuntu26
+            short_tag: latest-ubuntu26-22.x
+            short_tag2: latest-ubuntu26-22.x
             enabled: ${{ github.event.inputs.build_node_22 }}
     steps:
       - name: Check if build is enabled
         id: check
         run: |
-          if [[ "${{ matrix.enabled }}" != "true" ]]; then
+          node_enabled="${{ matrix.enabled }}"
+          ubuntu26_enabled="true"
+          if [[ "${{ matrix.os_label }}" == "ubuntu26" ]]; then
+            ubuntu26_enabled="${{ github.event.inputs.build_ubuntu_2604 }}"
+          fi
+          if [[ "$node_enabled" != "true" || "$ubuntu26_enabled" != "true" ]]; then
             echo "skip=true" >> $GITHUB_OUTPUT
           else
             echo "skip=false" >> $GITHUB_OUTPUT
@@ -445,7 +518,15 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         id: ghcr_tags
         run: |
-          TAGS="${{ matrix.node == '24.x' && needs.generate-tags.outputs.ubuntu_24 || needs.generate-tags.outputs.ubuntu_22 }}"
+          if [[ "${{ matrix.os_label }}" == "ubuntu26" ]]; then
+            if [[ "${{ matrix.node }}" == "24.x" ]]; then
+              TAGS="${{ needs.generate-tags.outputs.ubuntu_26_24 }}"
+            else
+              TAGS="${{ needs.generate-tags.outputs.ubuntu_26_22 }}"
+            fi
+          else
+            TAGS="${{ matrix.node == '24.x' && needs.generate-tags.outputs.ubuntu_24 || needs.generate-tags.outputs.ubuntu_22 }}"
+          fi
           {
             echo 'IMAGES<<EOF'
             echo "$TAGS" | tr ',' '\n' | grep "^${{ env.GHCR_REGISTRY }}/"
@@ -456,11 +537,11 @@ jobs:
         run: |
           set -euo pipefail
           echo "Waiting for build jobs to complete and images to be available..."
-          
+
           for arch in amd64 arm64; do
-            image="${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:${arch}-ubuntu-${{ matrix.node }}-${{ github.sha }}"
+            image="${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:${arch}-${{ matrix.os_label }}-${{ matrix.node }}-${{ github.sha }}"
             echo "Checking: $image"
-            
+
             for i in {1..60}; do
               if docker manifest inspect "$image" > /dev/null 2>&1; then
                 echo "✓ Image available: $image"
@@ -488,8 +569,8 @@ jobs:
             ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:${{ matrix.short_tag }}
             ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:${{ matrix.short_tag2 }}
           sources: |
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:amd64-ubuntu-${{ matrix.node }}-${{ github.sha }}
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:arm64-ubuntu-${{ matrix.node }}-${{ github.sha }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:amd64-${{ matrix.os_label }}-${{ matrix.node }}-${{ github.sha }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:arm64-${{ matrix.os_label }}-${{ matrix.node }}-${{ github.sha }}
 
   create-alpine-manifest:
     name: Alpine manifest
@@ -692,6 +773,16 @@ jobs:
             short_tag: latest
             tags_output: ubuntu_24
             enabled: ${{ github.event.inputs.build_docker_tags_ubuntu == 'true' && github.event.inputs.build_node_24 == 'true' }}
+          - os: ubuntu26
+            node: '22.x'
+            short_tag: latest-ubuntu26-22.x
+            tags_output: ubuntu_26_22
+            enabled: ${{ github.event.inputs.build_docker_tags_ubuntu == 'true' && github.event.inputs.build_ubuntu_2604 == 'true' && github.event.inputs.build_node_22 == 'true' }}
+          - os: ubuntu26
+            node: '24.x'
+            short_tag: latest-ubuntu26
+            tags_output: ubuntu_26_24
+            enabled: ${{ github.event.inputs.build_docker_tags_ubuntu == 'true' && github.event.inputs.build_ubuntu_2604 == 'true' && github.event.inputs.build_node_24 == 'true' }}
           - os: alpine
             node: '22'
             short_tag: latest-alpine-22


### PR DESCRIPTION
## Summary
This PR adds support for building Docker images with Ubuntu 26.04 as the base OS, alongside the existing Ubuntu 24.04 support. The changes enable conditional building of Ubuntu 26.04 images with both Node.js 22.x and 24.x versions.

## Key Changes
- **New workflow input**: Added `build_ubuntu_2604` boolean flag to allow users to opt-in to Ubuntu 26.04 image builds
- **Tag generation**: Extended the tag generation step to output separate tags for Ubuntu 26.04 builds (`ubuntu_26_22` and `ubuntu_26_24`)
- **Build matrix expansion**: Reorganized and expanded the build matrix to include Ubuntu 26.04 builds for both AMD64 and ARM architectures, with proper Node.js version support (22.x supports armv7, 24.x only arm64)
- **Conditional build logic**: Added checks in build and manifest creation jobs to respect the `build_ubuntu_2604` flag
- **Image tagging**: Updated image tag generation to use dynamic OS labels (`ubuntu` vs `ubuntu-26.04`) and base image versions
- **Manifest creation**: Extended the manifest creation job to handle Ubuntu 26.04 images with appropriate short tags (`latest-ubuntu-26.04`, `latest-ubuntu-26.04-22.x`, etc.)
- **Docker tags job**: Added Ubuntu 26.04 entries to the docker tags generation matrix with proper conditional enablement

## Implementation Details
- Ubuntu 26.04 builds are only triggered when both the `build_ubuntu_2604` flag and the respective Node.js version flag are enabled
- The build matrix now explicitly separates Ubuntu 24.04 and 26.04 configurations with clear OS labels
- Base image references are parameterized using `matrix.os` variable (e.g., `24.04-22.x` or `26.04-22.x`)
- Image naming convention updated to use `os_label` variable for flexibility (e.g., `amd64-ubuntu-26.04-22.x-<sha>`)

https://claude.ai/code/session_01KmrydRcGmvvE2qUKptuNY8