### PR TITLE
Add Ubuntu 26.04 support and use GITHUB_TOKEN for GHCR auth

### DIFF
--- a/.github/workflows/build sk docker container 24h.yml
+++ b/.github/workflows/build sk docker container 24h.yml
@@ -17,6 +17,10 @@ on:
         description: 'Build Debian docker image'
         type: boolean
         default: false
+      build_ubuntu_2604:
+        description: 'Build Ubuntu 26.04 docker image'
+        type: boolean
+        default: false
       build_node_22:
         description: 'Build Node.js 22 images'
         type: boolean
@@ -256,6 +260,8 @@ jobs:
     outputs:
       ubuntu_22: ${{ steps.tags.outputs.ubuntu_22 }}
       ubuntu_24: ${{ steps.tags.outputs.ubuntu_24 }}
+      ubuntu_26_22: ${{ steps.tags.outputs.ubuntu_26_22 }}
+      ubuntu_26_24: ${{ steps.tags.outputs.ubuntu_26_24 }}
       alpine_22: ${{ steps.tags.outputs.alpine_22 }}
       alpine_24: ${{ steps.tags.outputs.alpine_24 }}
       debian_22: ${{ steps.tags.outputs.debian_22 }}
@@ -269,13 +275,13 @@ jobs:
           MINOR="v${{ needs.signalk-server.outputs.major }}.${{ needs.signalk-server.outputs.minor }}"
           GHCR="${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}"
           HUB="${{ env.DOCKER_HUB_REPO }}"
-          
+
           # Function to generate tags
           generate_tags() {
             local variant=$1
             local node=$2
             local tags=""
-            
+
             if [[ "$TAG" == *beta* ]]; then
               tags="$GHCR:$TAG-$variant-$node"
               tags="$tags,$GHCR:latest-$variant-$node"
@@ -291,10 +297,10 @@ jobs:
               tags="$tags,$HUB:$MINOR-$variant-$node"
               tags="$tags,$HUB:latest-$variant-$node"
             fi
-            
+
             echo "$tags"
           }
-          
+
           # Generate tags for each variant (using consistent format)
           if [[ "${{ github.event.inputs.build_docker_tags_ubuntu }}" == "true" ]]; then
             if [[ "${{ github.event.inputs.build_node_22 }}" == "true" ]]; then
@@ -303,8 +309,16 @@ jobs:
             if [[ "${{ github.event.inputs.build_node_24 }}" == "true" ]]; then
               echo "ubuntu_24=$(generate_tags 'ubuntu' '24.x')" >> $GITHUB_OUTPUT
             fi
+            if [[ "${{ github.event.inputs.build_ubuntu_2604 }}" == "true" ]]; then
+              if [[ "${{ github.event.inputs.build_node_22 }}" == "true" ]]; then
+                echo "ubuntu_26_22=$(generate_tags 'ubuntu-26.04' '22.x')" >> $GITHUB_OUTPUT
+              fi
+              if [[ "${{ github.event.inputs.build_node_24 }}" == "true" ]]; then
+                echo "ubuntu_26_24=$(generate_tags 'ubuntu-26.04' '24.x')" >> $GITHUB_OUTPUT
+              fi
+            fi
           fi
-          
+
           if [[ "${{ github.event.inputs.build_docker_tags_alpine }}" == "true" ]]; then
             if [[ "${{ github.event.inputs.build_node_22 }}" == "true" ]]; then
               echo "alpine_22=$(generate_tags 'alpine' '22')" >> $GITHUB_OUTPUT
@@ -313,7 +327,7 @@ jobs:
               echo "alpine_24=$(generate_tags 'alpine' '24')" >> $GITHUB_OUTPUT
             fi
           fi
-          
+
           if [[ "${{ github.event.inputs.build_docker_tags_debian }}" == "true" ]]; then
             if [[ "${{ github.event.inputs.build_node_22 }}" == "true" ]]; then
               echo "debian_22=$(generate_tags 'debian' '22')" >> $GITHUB_OUTPUT
@@ -327,29 +341,70 @@ jobs:
     name: Build Ubuntu image
     if: ${{ github.event.inputs.build_docker_tags_ubuntu == 'true' }}
     needs: [generate-tags]
+    permissions:
+      contents: read
+      packages: write  # Required for GITHUB_TOKEN to push to GHCR
     strategy:
       fail-fast: false
       matrix:
         include:
-          # AMD64 builds for both node versions
+          # Ubuntu 24.04 AMD64 builds
           - vm: ubuntu-latest
             arch: amd64
+            os: '24.04'
+            os_label: ubuntu
             node: '22.x'
             platform: linux/amd64
             enabled: ${{ github.event.inputs.build_node_22 }}
           - vm: ubuntu-latest
             arch: amd64
+            os: '24.04'
+            os_label: ubuntu
             node: '24.x'
             platform: linux/amd64
             enabled: ${{ github.event.inputs.build_node_24 }}
-          # ARM builds (22.x supports armv7, 24.x only arm64)
+          # Ubuntu 24.04 ARM builds (22.x supports armv7, 24.x only arm64)
           - vm: ubuntu-24.04-arm
             arch: arm64
+            os: '24.04'
+            os_label: ubuntu
             node: '22.x'
             platform: linux/arm64,linux/arm/v7
             enabled: ${{ github.event.inputs.build_node_22 }}
           - vm: ubuntu-24.04-arm
             arch: arm64
+            os: '24.04'
+            os_label: ubuntu
+            node: '24.x'
+            platform: linux/arm64
+            enabled: ${{ github.event.inputs.build_node_24 }}
+          # Ubuntu 26.04 AMD64 builds
+          - vm: ubuntu-latest
+            arch: amd64
+            os: '26.04'
+            os_label: ubuntu-26.04
+            node: '22.x'
+            platform: linux/amd64
+            enabled: ${{ github.event.inputs.build_node_22 }}
+          - vm: ubuntu-latest
+            arch: amd64
+            os: '26.04'
+            os_label: ubuntu-26.04
+            node: '24.x'
+            platform: linux/amd64
+            enabled: ${{ github.event.inputs.build_node_24 }}
+          # Ubuntu 26.04 ARM builds (22.x supports armv7, 24.x only arm64)
+          - vm: ubuntu-24.04-arm
+            arch: arm64
+            os: '26.04'
+            os_label: ubuntu-26.04
+            node: '22.x'
+            platform: linux/arm64,linux/arm/v7
+            enabled: ${{ github.event.inputs.build_node_22 }}
+          - vm: ubuntu-24.04-arm
+            arch: arm64
+            os: '26.04'
+            os_label: ubuntu-26.04
             node: '24.x'
             platform: linux/arm64
             enabled: ${{ github.event.inputs.build_node_24 }}
@@ -358,7 +413,12 @@ jobs:
       - name: Check if build is enabled
         id: check
         run: |
-          if [[ "${{ matrix.enabled }}" != "true" ]]; then
+          node_enabled="${{ matrix.enabled }}"
+          ubuntu26_enabled="true"
+          if [[ "${{ matrix.os_label }}" == "ubuntu-26.04" ]]; then
+            ubuntu26_enabled="${{ github.event.inputs.build_ubuntu_2604 }}"
+          fi
+          if [[ "$node_enabled" != "true" || "$ubuntu26_enabled" != "true" ]]; then
             echo "skip=true" >> $GITHUB_OUTPUT
           else
             echo "skip=false" >> $GITHUB_OUTPUT
@@ -378,8 +438,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.GHCR_REGISTRY }}
-          username: ${{ secrets.GHCR_USERNAME }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}  # ✅ Replaced GHCR_USERNAME + GHCR_TOKEN
       - name: Build and push
         if: steps.check.outputs.skip != 'true'
         uses: docker/build-push-action@v6
@@ -391,14 +451,17 @@ jobs:
           provenance: true
           sbom: true
           tags: |
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:${{ matrix.arch }}-ubuntu-${{ matrix.node }}-${{ github.sha }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:${{ matrix.arch }}-${{ matrix.os_label }}-${{ matrix.node }}-${{ github.sha }}
           build-args: |
-            BASE_IMAGE=24.04-${{ matrix.node }}
+            BASE_IMAGE=${{ matrix.os }}-${{ matrix.node }}
 
   build-alpine-images:
     name: Build Alpine image
     if: ${{ github.event.inputs.build_docker_tags_alpine == 'true' }}
     needs: [generate-tags]
+    permissions:
+      contents: read
+      packages: write  # Required for GITHUB_TOKEN to push to GHCR
     strategy:
       fail-fast: false
       matrix:
@@ -450,8 +513,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.GHCR_REGISTRY }}
-          username: ${{ secrets.GHCR_USERNAME }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}  # ✅ Replaced GHCR_USERNAME + GHCR_TOKEN
       - name: Build and push
         if: steps.check.outputs.skip != 'true'
         uses: docker/build-push-action@v6
@@ -471,6 +534,9 @@ jobs:
     name: Build Debian image
     if: ${{ github.event.inputs.build_docker_tags_debian == 'true' }}
     needs: [generate-tags]
+    permissions:
+      contents: read
+      packages: write  # Required for GITHUB_TOKEN to push to GHCR
     strategy:
       fail-fast: false
       matrix:
@@ -522,8 +588,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.GHCR_REGISTRY }}
-          username: ${{ secrets.GHCR_USERNAME }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}  # ✅ Replaced GHCR_USERNAME + GHCR_TOKEN
       - name: Build and push
         if: steps.check.outputs.skip != 'true'
         uses: docker/build-push-action@v6
@@ -544,23 +610,42 @@ jobs:
     if: ${{ github.event.inputs.build_docker_tags_ubuntu == 'true' }}
     needs: [build-ubuntu-images, generate-tags]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write  # Required for GITHUB_TOKEN to push to GHCR
     strategy:
       matrix:
-        node: ['22.x', '24.x']
         include:
           - node: '24.x'
+            os_label: ubuntu
             short_tag: latest
             short_tag2: latest-24.x
             enabled: ${{ github.event.inputs.build_node_24 }}
           - node: '22.x'
+            os_label: ubuntu
             short_tag: latest-22.x
             short_tag2: latest-22.x
+            enabled: ${{ github.event.inputs.build_node_22 }}
+          - node: '24.x'
+            os_label: ubuntu-26.04
+            short_tag: latest-ubuntu-26.04
+            short_tag2: latest-ubuntu-26.04-24.x
+            enabled: ${{ github.event.inputs.build_node_24 }}
+          - node: '22.x'
+            os_label: ubuntu-26.04
+            short_tag: latest-ubuntu-26.04-22.x
+            short_tag2: latest-ubuntu-26.04-22.x
             enabled: ${{ github.event.inputs.build_node_22 }}
     steps:
       - name: Check if build is enabled
         id: check
         run: |
-          if [[ "${{ matrix.enabled }}" != "true" ]]; then
+          node_enabled="${{ matrix.enabled }}"
+          ubuntu26_enabled="true"
+          if [[ "${{ matrix.os_label }}" == "ubuntu-26.04" ]]; then
+            ubuntu26_enabled="${{ github.event.inputs.build_ubuntu_2604 }}"
+          fi
+          if [[ "$node_enabled" != "true" || "$ubuntu26_enabled" != "true" ]]; then
             echo "skip=true" >> $GITHUB_OUTPUT
           else
             echo "skip=false" >> $GITHUB_OUTPUT
@@ -576,13 +661,21 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.GHCR_REGISTRY }}
-          username: ${{ secrets.GHCR_USERNAME }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}  # ✅ Replaced GHCR_USERNAME + GHCR_TOKEN
       - name: Extract GHCR tags
         if: steps.check.outputs.skip != 'true'
         id: ghcr_tags
         run: |
-          TAGS="${{ matrix.node == '24.x' && needs.generate-tags.outputs.ubuntu_24 || needs.generate-tags.outputs.ubuntu_22 }}"
+          if [[ "${{ matrix.os_label }}" == "ubuntu-26.04" ]]; then
+            if [[ "${{ matrix.node }}" == "24.x" ]]; then
+              TAGS="${{ needs.generate-tags.outputs.ubuntu_26_24 }}"
+            else
+              TAGS="${{ needs.generate-tags.outputs.ubuntu_26_22 }}"
+            fi
+          else
+            TAGS="${{ matrix.node == '24.x' && needs.generate-tags.outputs.ubuntu_24 || needs.generate-tags.outputs.ubuntu_22 }}"
+          fi
           {
             echo 'IMAGES<<EOF'
             echo "$TAGS" | tr ',' '\n' | grep "^${{ env.GHCR_REGISTRY }}/"
@@ -593,11 +686,11 @@ jobs:
         run: |
           set -euo pipefail
           echo "Waiting for build jobs to complete and images to be available..."
-          
+
           for arch in amd64 arm64; do
-            image="${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:${arch}-ubuntu-${{ matrix.node }}-${{ github.sha }}"
+            image="${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:${arch}-${{ matrix.os_label }}-${{ matrix.node }}-${{ github.sha }}"
             echo "Checking: $image"
-            
+
             for i in {1..60}; do
               if docker manifest inspect "$image" > /dev/null 2>&1; then
                 echo "✓ Image available: $image"
@@ -625,14 +718,17 @@ jobs:
             ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:${{ matrix.short_tag }}
             ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:${{ matrix.short_tag2 }}
           sources: |
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:amd64-ubuntu-${{ matrix.node }}-${{ github.sha }}
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:arm64-ubuntu-${{ matrix.node }}-${{ github.sha }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:amd64-${{ matrix.os_label }}-${{ matrix.node }}-${{ github.sha }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}:arm64-${{ matrix.os_label }}-${{ matrix.node }}-${{ github.sha }}
 
   create-alpine-manifest:
     name: Alpine manifest
     if: ${{ github.event.inputs.build_docker_tags_alpine == 'true' }}
     needs: [build-alpine-images, generate-tags]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write  # Required for GITHUB_TOKEN to push to GHCR
     strategy:
       matrix:
         node: ['22', '24']
@@ -663,8 +759,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.GHCR_REGISTRY }}
-          username: ${{ secrets.GHCR_USERNAME }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}  # ✅ Replaced GHCR_USERNAME + GHCR_TOKEN
       - name: Extract GHCR tags
         if: steps.check.outputs.skip != 'true'
         id: ghcr_tags
@@ -719,6 +815,9 @@ jobs:
     if: ${{ github.event.inputs.build_docker_tags_debian == 'true' }}
     needs: [build-debian-images, generate-tags]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write  # Required for GITHUB_TOKEN to push to GHCR
     strategy:
       matrix:
         node: ['22', '24']
@@ -749,8 +848,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.GHCR_REGISTRY }}
-          username: ${{ secrets.GHCR_USERNAME }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}  # ✅ Replaced GHCR_USERNAME + GHCR_TOKEN
       - name: Extract GHCR tags
         if: steps.check.outputs.skip != 'true'
         id: ghcr_tags
@@ -823,6 +922,16 @@ jobs:
             short_tag: latest
             tags_output: ubuntu_24
             enabled: ${{ github.event.inputs.build_docker_tags_ubuntu == 'true' && github.event.inputs.build_node_24 == 'true' }}
+          - os: ubuntu-26.04
+            node: '22.x'
+            short_tag: latest-ubuntu-26.04-22.x
+            tags_output: ubuntu_26_22
+            enabled: ${{ github.event.inputs.build_docker_tags_ubuntu == 'true' && github.event.inputs.build_ubuntu_2604 == 'true' && github.event.inputs.build_node_22 == 'true' }}
+          - os: ubuntu-26.04
+            node: '24.x'
+            short_tag: latest-ubuntu-26.04
+            tags_output: ubuntu_26_24
+            enabled: ${{ github.event.inputs.build_docker_tags_ubuntu == 'true' && github.event.inputs.build_ubuntu_2604 == 'true' && github.event.inputs.build_node_24 == 'true' }}
           - os: alpine
             node: '22'
             short_tag: latest-alpine-22
@@ -913,6 +1022,7 @@ jobs:
 
   housekeeping:
     name: Housekeeping
+    if: always()
     needs: [copy-to-dockerhub]
     runs-on: ubuntu-latest
     permissions:
@@ -941,7 +1051,7 @@ jobs:
           delete-untagged: true
           delete-tags: |
             *-${{ github.sha }}
-          token: ${{ secrets.GHCR_TOKEN_NEW }}
+          token: ${{ secrets.GITHUB_TOKEN }}  # ✅ Replaced GHCR_TOKEN_NEW
 
   slack:
     name: Slack notification


### PR DESCRIPTION
## Summary
This PR adds support for building Docker images with Ubuntu 26.04 and replaces custom GHCR credentials with the standard `GITHUB_TOKEN` for authentication to GitHub Container Registry.

## Key Changes

- **Ubuntu 26.04 Support**: Added new `build_ubuntu_2604` input parameter to enable optional Ubuntu 26.04 image builds alongside existing Ubuntu 24.04 builds
  - Extended build matrix to include Ubuntu 26.04 variants for both Node.js 22.x and 24.x
  - Added tag generation for `ubuntu_26_22` and `ubuntu_26_24` outputs
  - Implemented conditional logic to skip Ubuntu 26.04 builds when not explicitly enabled

- **Authentication Improvements**: Replaced custom GHCR credentials with `GITHUB_TOKEN`
  - Changed from `secrets.GHCR_USERNAME` + `secrets.GHCR_TOKEN` to `github.actor` + `secrets.GITHUB_TOKEN`
  - Applied consistently across all Docker login steps (Ubuntu, Alpine, Debian builds and manifests)
  - Updated housekeeping job to use `GITHUB_TOKEN` instead of `GHCR_TOKEN_NEW`
  - Added explicit `permissions` blocks to jobs requiring package write access

- **Build Matrix Reorganization**: Restructured Ubuntu build matrix for clarity
  - Separated Ubuntu 24.04 and 26.04 build configurations
  - Added `os` and `os_label` matrix variables for better parameterization
  - Updated tag generation to use dynamic `os_label` instead of hardcoded values

- **Manifest Creation**: Extended manifest jobs to handle Ubuntu 26.04 variants
  - Added Ubuntu 26.04 entries to the manifest creation strategy matrix
  - Implemented conditional tag extraction based on OS label

- **Code Quality**: Minor whitespace cleanup and improved conditional checks in build skip logic

## Implementation Details

The Ubuntu 26.04 builds are fully optional and only execute when the `build_ubuntu_2604` input is explicitly set to `true`. The build matrix now includes both OS version and label information, allowing the same build logic to handle multiple Ubuntu versions without duplication. All authentication now relies on the standard GitHub-provided token, eliminating the need for custom secret management.

https://claude.ai/code/session_01Dmakw8RiFrjaB2vbaYjUwD