### PR TITLE
Add Ubuntu 24.04 build option to Docker workflow

### DIFF
--- a/.github/workflows/build sk docker container all.yml
+++ b/.github/workflows/build sk docker container all.yml
@@ -15,6 +15,10 @@ on:
         description: 'Build Debian docker image'
         type: boolean
         default: false
+      build_ubuntu_2404:
+        description: 'Build Ubuntu 24.04 docker image'
+        type: boolean
+        default: true
       build_ubuntu_2604:
         description: 'Build Ubuntu 26.04 docker image'
         type: boolean
@@ -154,11 +158,13 @@ jobs:
           
           # Generate tags for each variant (using consistent format)
           if [[ "${{ github.event.inputs.build_docker_tags_ubuntu }}" == "true" ]]; then
-            if [[ "${{ github.event.inputs.build_node_22 }}" == "true" ]]; then
-              echo "ubuntu_22=$(generate_tags 'ubuntu' '22.x')" >> $GITHUB_OUTPUT
-            fi
-            if [[ "${{ github.event.inputs.build_node_24 }}" == "true" ]]; then
-              echo "ubuntu_24=$(generate_tags 'ubuntu' '24.x')" >> $GITHUB_OUTPUT
+            if [[ "${{ github.event.inputs.build_ubuntu_2404 }}" == "true" ]]; then
+              if [[ "${{ github.event.inputs.build_node_22 }}" == "true" ]]; then
+                echo "ubuntu_22=$(generate_tags 'ubuntu' '22.x')" >> $GITHUB_OUTPUT
+              fi
+              if [[ "${{ github.event.inputs.build_node_24 }}" == "true" ]]; then
+                echo "ubuntu_24=$(generate_tags 'ubuntu' '24.x')" >> $GITHUB_OUTPUT
+              fi
             fi
             if [[ "${{ github.event.inputs.build_ubuntu_2604 }}" == "true" ]]; then
               if [[ "${{ github.event.inputs.build_node_22 }}" == "true" ]]; then
@@ -265,11 +271,13 @@ jobs:
         id: check
         run: |
           node_enabled="${{ matrix.enabled }}"
-          ubuntu26_enabled="true"
+          ubuntu_os_enabled="true"
           if [[ "${{ matrix.os_label }}" == "ubuntu-26.04" ]]; then
-            ubuntu26_enabled="${{ github.event.inputs.build_ubuntu_2604 }}"
+            ubuntu_os_enabled="${{ github.event.inputs.build_ubuntu_2604 }}"
+          elif [[ "${{ matrix.os_label }}" == "ubuntu" ]]; then
+            ubuntu_os_enabled="${{ github.event.inputs.build_ubuntu_2404 }}"
           fi
-          if [[ "$node_enabled" != "true" || "$ubuntu26_enabled" != "true" ]]; then
+          if [[ "$node_enabled" != "true" || "$ubuntu_os_enabled" != "true" ]]; then
             echo "skip=true" >> $GITHUB_OUTPUT
           else
             echo "skip=false" >> $GITHUB_OUTPUT
@@ -492,11 +500,13 @@ jobs:
         id: check
         run: |
           node_enabled="${{ matrix.enabled }}"
-          ubuntu26_enabled="true"
+          ubuntu_os_enabled="true"
           if [[ "${{ matrix.os_label }}" == "ubuntu-26.04" ]]; then
-            ubuntu26_enabled="${{ github.event.inputs.build_ubuntu_2604 }}"
+            ubuntu_os_enabled="${{ github.event.inputs.build_ubuntu_2604 }}"
+          elif [[ "${{ matrix.os_label }}" == "ubuntu" ]]; then
+            ubuntu_os_enabled="${{ github.event.inputs.build_ubuntu_2404 }}"
           fi
-          if [[ "$node_enabled" != "true" || "$ubuntu26_enabled" != "true" ]]; then
+          if [[ "$node_enabled" != "true" || "$ubuntu_os_enabled" != "true" ]]; then
             echo "skip=true" >> $GITHUB_OUTPUT
           else
             echo "skip=false" >> $GITHUB_OUTPUT
@@ -767,12 +777,12 @@ jobs:
             node: '22.x'
             short_tag: latest-22.x
             tags_output: ubuntu_22
-            enabled: ${{ github.event.inputs.build_docker_tags_ubuntu == 'true' && github.event.inputs.build_node_22 == 'true' }}
+            enabled: ${{ github.event.inputs.build_docker_tags_ubuntu == 'true' && github.event.inputs.build_ubuntu_2404 == 'true' && github.event.inputs.build_node_22 == 'true' }}
           - os: ubuntu
             node: '24.x'
             short_tag: latest
             tags_output: ubuntu_24
-            enabled: ${{ github.event.inputs.build_docker_tags_ubuntu == 'true' && github.event.inputs.build_node_24 == 'true' }}
+            enabled: ${{ github.event.inputs.build_docker_tags_ubuntu == 'true' && github.event.inputs.build_ubuntu_2404 == 'true' && github.event.inputs.build_node_24 == 'true' }}
           - os: ubuntu-26.04
             node: '22.x'
             short_tag: latest-ubuntu-26.04-22.x


### PR DESCRIPTION
## Summary
This PR adds explicit support for Ubuntu 24.04 as a configurable build option in the Docker container build workflow, allowing users to control whether Ubuntu 24.04 images are built independently from Ubuntu 26.04 images.

## Key Changes
- Added `build_ubuntu_2404` workflow input parameter (enabled by default) to control Ubuntu 24.04 Docker image builds
- Updated tag generation logic to only generate Ubuntu tags when `build_ubuntu_2404` is enabled
- Refactored OS-specific build checks to support both Ubuntu 24.04 and Ubuntu 26.04 with separate configuration options
- Renamed internal variable `ubuntu26_enabled` to `ubuntu_os_enabled` for clarity and reusability across multiple OS versions
- Updated matrix job conditions to include the `build_ubuntu_2404` flag alongside existing Node.js version checks

## Implementation Details
- The new input parameter defaults to `true` to maintain backward compatibility with existing workflows
- Build skip logic now properly evaluates both the Node.js version and the specific Ubuntu OS version being targeted
- Changes applied consistently across multiple job definitions (tag generation, build, and push jobs)
- The refactoring allows for independent control of Ubuntu 24.04 and Ubuntu 26.04 builds while maintaining the existing Node.js version selection logic

https://claude.ai/code/session_014ucngHZgBAgr8gSJ9K2u81