### PR TITLE
Refactor Ubuntu Docker build workflow to use version-specific inputs

### DIFF
--- a/.github/workflows/build sk docker container all.yml
+++ b/.github/workflows/build sk docker container all.yml
@@ -3,10 +3,6 @@ name: SignalK Docker Build - Ubuntu + Alpine + Debian
 on:
   workflow_dispatch:
     inputs:
-      build_docker_tags_ubuntu:
-        description: 'Build Ubuntu docker image'
-        type: boolean
-        default: true
       build_docker_tags_alpine:
         description: 'Build Alpine docker image'
         type: boolean
@@ -157,7 +153,7 @@ jobs:
           }
           
           # Generate tags for each variant (using consistent format)
-          if [[ "${{ github.event.inputs.build_docker_tags_ubuntu }}" == "true" ]]; then
+          if [[ "${{ github.event.inputs.build_ubuntu_2404 }}" == "true" || "${{ github.event.inputs.build_ubuntu_2604 }}" == "true" ]]; then
             if [[ "${{ github.event.inputs.build_ubuntu_2404 }}" == "true" ]]; then
               if [[ "${{ github.event.inputs.build_node_22 }}" == "true" ]]; then
                 echo "ubuntu_22=$(generate_tags 'ubuntu' '22.x')" >> $GITHUB_OUTPUT
@@ -196,7 +192,7 @@ jobs:
 
   build-ubuntu-images:
     name: Build Ubuntu image
-    if: ${{ github.event.inputs.build_docker_tags_ubuntu == 'true' }}
+    if: ${{ github.event.inputs.build_ubuntu_2404 == 'true' || github.event.inputs.build_ubuntu_2604 == 'true' }}
     needs: [generate-tags]
     permissions:
       contents: read
@@ -466,7 +462,7 @@ jobs:
 
   create-ubuntu-manifest:
     name: Ubuntu manifest
-    if: ${{ github.event.inputs.build_docker_tags_ubuntu == 'true' }}
+    if: ${{ github.event.inputs.build_ubuntu_2404 == 'true' || github.event.inputs.build_ubuntu_2604 == 'true' }}
     needs: [build-ubuntu-images, generate-tags]
     runs-on: ubuntu-latest
     permissions:
@@ -777,22 +773,22 @@ jobs:
             node: '22.x'
             short_tag: latest-22.x
             tags_output: ubuntu_22
-            enabled: ${{ github.event.inputs.build_docker_tags_ubuntu == 'true' && github.event.inputs.build_ubuntu_2404 == 'true' && github.event.inputs.build_node_22 == 'true' }}
+            enabled: ${{ github.event.inputs.build_ubuntu_2404 == 'true' && github.event.inputs.build_node_22 == 'true' }}
           - os: ubuntu
             node: '24.x'
             short_tag: latest
             tags_output: ubuntu_24
-            enabled: ${{ github.event.inputs.build_docker_tags_ubuntu == 'true' && github.event.inputs.build_ubuntu_2404 == 'true' && github.event.inputs.build_node_24 == 'true' }}
+            enabled: ${{ github.event.inputs.build_ubuntu_2404 == 'true' && github.event.inputs.build_node_24 == 'true' }}
           - os: ubuntu-26.04
             node: '22.x'
             short_tag: latest-ubuntu-26.04-22.x
             tags_output: ubuntu_26_22
-            enabled: ${{ github.event.inputs.build_docker_tags_ubuntu == 'true' && github.event.inputs.build_ubuntu_2604 == 'true' && github.event.inputs.build_node_22 == 'true' }}
+            enabled: ${{ github.event.inputs.build_ubuntu_2604 == 'true' && github.event.inputs.build_node_22 == 'true' }}
           - os: ubuntu-26.04
             node: '24.x'
             short_tag: latest-ubuntu-26.04
             tags_output: ubuntu_26_24
-            enabled: ${{ github.event.inputs.build_docker_tags_ubuntu == 'true' && github.event.inputs.build_ubuntu_2604 == 'true' && github.event.inputs.build_node_24 == 'true' }}
+            enabled: ${{ github.event.inputs.build_ubuntu_2604 == 'true' && github.event.inputs.build_node_24 == 'true' }}
           - os: alpine
             node: '22'
             short_tag: latest-alpine-22


### PR DESCRIPTION
## Summary
Replaced the generic `build_docker_tags_ubuntu` boolean input with version-specific Ubuntu inputs (`build_ubuntu_2404` and `build_ubuntu_2604`) throughout the Docker build workflow. This allows for more granular control over which Ubuntu versions are built.

## Key Changes
- Removed the `build_docker_tags_ubuntu` workflow input parameter
- Updated all conditional checks that previously relied on `build_docker_tags_ubuntu` to instead check for either `build_ubuntu_2404` or `build_ubuntu_2604`
- Simplified matrix job `enabled` conditions by removing the redundant `build_docker_tags_ubuntu` check, keeping only the version-specific and Node.js version checks
- Applied changes across three main workflow sections:
  - Tag generation logic
  - Ubuntu image build job condition
  - Ubuntu manifest creation job condition
  - Build matrix job enabled conditions for all Ubuntu variants

## Implementation Details
The refactoring maintains the same logical behavior while providing finer-grained control. Users can now independently enable/disable builds for Ubuntu 24.04 and Ubuntu 26.04, rather than having a single toggle for all Ubuntu builds. The workflow will proceed with Ubuntu-related jobs if either version is enabled.

https://claude.ai/code/session_016Y2f2qiUijYfZ532ASvMpx