### PR TITLE
Update course-provider dependency to v1.2.7

### DIFF
--- a/patch/04-dnssd2/astro.patch
+++ b/patch/04-dnssd2/astro.patch
@@ -32,7 +32,7 @@ index ace9256ab..324605bc1 100644
    "dependencies": {
      "@assemblyscript/loader": "^0.28.9",
 +    "@astronautlabs/mdns": "^1.0.10",
-     "@signalk/course-provider": "^1.0.0",
+     "@signalk/course-provider": "^1.2.7",
      "@signalk/n2k-signalk": ">=4.1.0-beta",
      "@signalk/nmea0183-signalk": "^3.0.0",
 @@ -98,7 +99,6 @@


### PR DESCRIPTION
## Summary
Updates the `@signalk/course-provider` dependency from v1.0.0 to v1.2.7 to leverage improvements and bug fixes in the newer version.

## Changes
- Bumped `@signalk/course-provider` from `^1.0.0` to `^1.2.7`

## Notes
This is a minor version update that maintains backward compatibility while providing access to enhancements in the course-provider package.

https://claude.ai/code/session_01QYX726D3T16HQLC1GYDFqb