### PR TITLE
Upgrade Node.js to v24 for Docker and GitHub Actions

### DIFF
--- a/.github/workflows/build docker base container all.yml
+++ b/.github/workflows/build docker base container all.yml
@@ -30,6 +30,7 @@ env:
   GHCR_REGISTRY: ghcr.io
   GHCR_REPO: kegustafsson/signalk-server-base
   DOCKER_HUB_REPO: kgustafs/signalk-server-base
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   prepare:

--- a/.github/workflows/build sk docker container 24h.yml
+++ b/.github/workflows/build sk docker container 24h.yml
@@ -34,6 +34,7 @@ env:
   GHCR_REGISTRY: ghcr.io
   GHCR_REPO: kegustafsson/signalk-server
   DOCKER_HUB_REPO: kgustafs/signalk-server
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   check-new-v-tags:

--- a/.github/workflows/build sk docker container all org.yml
+++ b/.github/workflows/build sk docker container all org.yml
@@ -28,6 +28,7 @@ env:
   GHCR_REGISTRY: ghcr.io
   GHCR_REPO: kegustafsson/signalk-server
   DOCKER_HUB_REPO: kgustafs/signalk-server
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   specification:

--- a/.github/workflows/build sk docker container all.yml
+++ b/.github/workflows/build sk docker container all.yml
@@ -32,6 +32,7 @@ env:
   GHCR_REGISTRY: ghcr.io
   GHCR_REPO: kegustafsson/signalk-server
   DOCKER_HUB_REPO: kgustafs/signalk-server
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   signalk-server:

--- a/docker/Dockerfile_base_alpine
+++ b/docker/Dockerfile_base_alpine
@@ -1,4 +1,4 @@
-ARG NODE
+ARG NODE=24
 FROM node:${NODE}-alpine
 
 COPY docker/avahi/avahi-dbus.conf docker/bluez/bluezuser.conf /etc/dbus-1/system.d/


### PR DESCRIPTION
## Summary
This pull request upgrades the Node.js runtime to version 24 across Docker containers and GitHub Actions workflows.

## Key Changes
- **Docker Base Image**: Set default Node.js version to 24 in `Dockerfile_base_alpine` by adding `ARG NODE=24`
- **GitHub Actions Workflows**: Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` environment variable to all four build workflow files:
  - `build docker base container all.yml`
  - `build sk docker container 24h.yml`
  - `build sk docker container all org.yml`
  - `build sk docker container all.yml`

## Implementation Details
The Node.js version upgrade ensures consistency across the entire CI/CD pipeline and containerized environments. The `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` flag explicitly configures GitHub Actions to use Node.js 24 for JavaScript-based actions, preventing potential compatibility issues with older Node.js versions that may be deprecated in future GitHub Actions releases.

https://claude.ai/code/session_01TvYr7VGfvLfr1Xg759vJF9