### PR TITLE
Centralize Docker build matrix configuration to JSON

### DIFF
--- a/.github/build-matrix.json
+++ b/.github/build-matrix.json
@@ -1,0 +1,77 @@
+{
+  "_comment": "Single source of truth for OS x Node combinations the workflows can build. To add a new OS, append an entry to os_variants and a matching workflow_dispatch input (one per node version) to .github/workflows/build sk docker container all.yml and build docker base container all.yml. To add a new Node major, append to node_versions and add manifest_short_tags entries on every os_variants row, plus matching workflow_dispatch inputs.",
+  "os_variants": [
+    {
+      "id": "ubuntu-24.04",
+      "family": "ubuntu",
+      "base_os_label": "24.04",
+      "user_os_label": "ubuntu",
+      "user_os_arg": "24.04",
+      "dockerfile": "./docker/Dockerfile_base_24.04_user",
+      "build_test": true,
+      "login_dhi": false,
+      "default_enabled": true,
+      "manifest_short_tags": {
+        "22": ["latest-22.x"],
+        "24": ["latest", "latest-24.x"]
+      }
+    },
+    {
+      "id": "ubuntu-26.04",
+      "family": "ubuntu",
+      "base_os_label": "26.04",
+      "user_os_label": "ubuntu-26.04",
+      "user_os_arg": "26.04",
+      "dockerfile": "./docker/Dockerfile_base_26.04_user",
+      "build_test": true,
+      "login_dhi": false,
+      "default_enabled": true,
+      "manifest_short_tags": {
+        "22": ["latest-ubuntu-26.04-22.x"],
+        "24": ["latest-ubuntu-26.04", "latest-ubuntu-26.04-24.x"]
+      }
+    },
+    {
+      "id": "alpine",
+      "family": "alpine",
+      "base_os_label": "alpine",
+      "user_os_label": "alpine",
+      "user_os_arg": "alpine",
+      "dockerfile": "./docker/Dockerfile_base_alpine",
+      "build_test": false,
+      "login_dhi": true,
+      "default_enabled": true,
+      "manifest_short_tags": {
+        "22": ["latest-alpine-22"],
+        "24": ["latest-alpine"]
+      }
+    },
+    {
+      "id": "debian",
+      "family": "debian",
+      "base_os_label": "debian",
+      "user_os_label": "debian",
+      "user_os_arg": "debian",
+      "dockerfile": "./docker/Dockerfile_base_debian",
+      "build_test": false,
+      "login_dhi": false,
+      "default_enabled": false,
+      "manifest_short_tags": {
+        "22": ["latest-debian-22"],
+        "24": ["latest-debian"]
+      }
+    }
+  ],
+  "node_versions": [
+    {
+      "id": "22",
+      "ubuntu_format": "22.x",
+      "default_enabled": false
+    },
+    {
+      "id": "24",
+      "ubuntu_format": "24.x",
+      "default_enabled": true
+    }
+  ]
+}

--- a/.github/workflows/build docker base container all.yml
+++ b/.github/workflows/build docker base container all.yml
@@ -3,28 +3,44 @@ name: Build Docker base images user (Ubuntu + Alpine + Debian-Slim)
 on:
   schedule:
     - cron: "0 0 * * 1"
+  # Per-(OS x Node) checkboxes. The catalogue of available combinations
+  # lives in .github/build-matrix.json - add a row there, then add a
+  # matching input below. Input names must be: <os_id_with_-_and_._mapped_to__>_node_<node_id>.
+  # Scheduled runs ignore inputs and use default_enabled from the JSON.
   workflow_dispatch:
     inputs:
-      ubuntu:
-        description: 'Build Ubuntu base image'
-        type: boolean
-        default: true
-      alpine:
-        description: 'Build Alpine base image'
-        type: boolean
-        default: true
-      debian:
-        description: 'Build Debian base image'
+      ubuntu_24_04_node_22:
+        description: 'Ubuntu 24.04 + Node 22.x'
         type: boolean
         default: false
-      build_node_22:
-        description: 'Build Node.js 22 images'
-        type: boolean
-        default: false
-      build_node_24:
-        description: 'Build Node.js 24 images'
+      ubuntu_24_04_node_24:
+        description: 'Ubuntu 24.04 + Node 24.x'
         type: boolean
         default: true
+      ubuntu_26_04_node_22:
+        description: 'Ubuntu 26.04 + Node 22.x'
+        type: boolean
+        default: false
+      ubuntu_26_04_node_24:
+        description: 'Ubuntu 26.04 + Node 24.x'
+        type: boolean
+        default: true
+      alpine_node_22:
+        description: 'Alpine + Node 22'
+        type: boolean
+        default: false
+      alpine_node_24:
+        description: 'Alpine + Node 24'
+        type: boolean
+        default: true
+      debian_node_22:
+        description: 'Debian + Node 22'
+        type: boolean
+        default: false
+      debian_node_24:
+        description: 'Debian + Node 24'
+        type: boolean
+        default: false
 
 env:
   GHCR_REGISTRY: ghcr.io
@@ -41,38 +57,38 @@ jobs:
       variant_matrix: ${{ steps.matrix.outputs.variant_matrix }}
       any_enabled: ${{ steps.matrix.outputs.any_enabled }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
       - name: Compute matrices
         id: matrix
         env:
-          # Schedule runs leave inputs empty -> fall back to the dispatch defaults.
-          UBUNTU: ${{ github.event.inputs.ubuntu }}
-          ALPINE: ${{ github.event.inputs.alpine }}
-          DEBIAN: ${{ github.event.inputs.debian }}
-          NODE_22: ${{ github.event.inputs.build_node_22 }}
-          NODE_24: ${{ github.event.inputs.build_node_24 }}
+          # Schedule runs leave inputs empty -> fall back to default_enabled in build-matrix.json.
+          ENABLED_JSON: ${{ toJSON(github.event.inputs) }}
         run: |
           set -euo pipefail
 
-          # Variant catalogue. To add a new OS / Node combo, add a row here.
-          variants=$(jq -nc \
-            --arg ubuntu "${UBUNTU:-true}" \
-            --arg alpine "${ALPINE:-true}" \
-            --arg debian "${DEBIAN:-false}" \
-            --arg n22 "${NODE_22:-false}" \
-            --arg n24 "${NODE_24:-true}" '
-            [
-              {family:"ubuntu", os_label:"24.04",  node:"22.x", dockerfile:"./docker/Dockerfile_base_24.04_user", build_test:true,  login_dhi:false, os_en:$ubuntu, node_en:$n22},
-              {family:"ubuntu", os_label:"24.04",  node:"24.x", dockerfile:"./docker/Dockerfile_base_24.04_user", build_test:true,  login_dhi:false, os_en:$ubuntu, node_en:$n24},
-              {family:"ubuntu", os_label:"26.04",  node:"22.x", dockerfile:"./docker/Dockerfile_base_26.04_user", build_test:true,  login_dhi:false, os_en:$ubuntu, node_en:$n22},
-              {family:"ubuntu", os_label:"26.04",  node:"24.x", dockerfile:"./docker/Dockerfile_base_26.04_user", build_test:true,  login_dhi:false, os_en:$ubuntu, node_en:$n24},
-              {family:"alpine", os_label:"alpine", node:"22",   dockerfile:"./docker/Dockerfile_base_alpine",     build_test:false, login_dhi:true,  os_en:$alpine, node_en:$n22},
-              {family:"alpine", os_label:"alpine", node:"24",   dockerfile:"./docker/Dockerfile_base_alpine",     build_test:false, login_dhi:true,  os_en:$alpine, node_en:$n24},
-              {family:"debian", os_label:"debian", node:"22",   dockerfile:"./docker/Dockerfile_base_debian",     build_test:false, login_dhi:false, os_en:$debian, node_en:$n22},
-              {family:"debian", os_label:"debian", node:"24",   dockerfile:"./docker/Dockerfile_base_debian",     build_test:false, login_dhi:false, os_en:$debian, node_en:$n24}
-            ]
-            | map(select(.os_en == "true" and .node_en == "true"))
-            | map(del(.os_en, .node_en))
-          ')
+          # Cross-product os_variants x node_versions from .github/build-matrix.json,
+          # then filter by the per-row dispatch checkbox (or by default_enabled
+          # for scheduled runs).
+          variants=$(jq -c \
+            --argjson enabled "${ENABLED_JSON:-null}" '
+            (if ($enabled | type) == "object" then $enabled else {} end) as $en
+            | .os_variants as $os | .node_versions as $nodes
+            | [ $os[] as $o | $nodes[] as $n |
+                (($o.id | gsub("[-.]"; "_")) + "_node_" + $n.id) as $key |
+                {
+                  enabled: ($en[$key] // (if ($o.default_enabled and $n.default_enabled) then "true" else "false" end)),
+                  family:     $o.family,
+                  os_label:   $o.base_os_label,
+                  node:       (if $o.family == "ubuntu" then $n.ubuntu_format else $n.id end),
+                  dockerfile: $o.dockerfile,
+                  build_test: $o.build_test,
+                  login_dhi:  $o.login_dhi
+                }
+              ]
+            | map(select(.enabled == "true"))
+            | map(del(.enabled))
+          ' .github/build-matrix.json)
 
           # Build matrix: one row per (variant, arch). Node 22 builds also produce arm/v7.
           # NB: arch suffix is amd/arm (not amd64/arm64) to match existing base image tags.

--- a/.github/workflows/build sk docker container 24h.yml
+++ b/.github/workflows/build sk docker container 24h.yml
@@ -3,32 +3,44 @@ name: SignalK Docker Build 24h
 on:
   schedule:
     - cron: "0 1 * * *"
+  # Per-(OS x Node) checkboxes. The catalogue of available combinations
+  # lives in .github/build-matrix.json - add a row there, then add a
+  # matching input below. Input names must be: <os_id_with_-_and_._mapped_to__>_node_<node_id>.
+  # Scheduled runs ignore inputs and use default_enabled from the JSON.
   workflow_dispatch:
     inputs:
-      build_docker_tags_alpine:
-        description: 'Build Alpine docker image'
-        type: boolean
-        default: true
-      build_docker_tags_debian:
-        description: 'Build Debian docker image'
+      ubuntu_24_04_node_22:
+        description: 'Ubuntu 24.04 + Node 22.x'
         type: boolean
         default: false
-      build_ubuntu_2404:
-        description: 'Build Ubuntu 24.04 docker image'
+      ubuntu_24_04_node_24:
+        description: 'Ubuntu 24.04 + Node 24.x'
         type: boolean
         default: true
-      build_ubuntu_2604:
-        description: 'Build Ubuntu 26.04 docker image'
-        type: boolean
-        default: true
-      build_node_22:
-        description: 'Build Node.js 22 images'
+      ubuntu_26_04_node_22:
+        description: 'Ubuntu 26.04 + Node 22.x'
         type: boolean
         default: false
-      build_node_24:
-        description: 'Build Node.js 24 images'
+      ubuntu_26_04_node_24:
+        description: 'Ubuntu 26.04 + Node 24.x'
         type: boolean
         default: true
+      alpine_node_22:
+        description: 'Alpine + Node 22'
+        type: boolean
+        default: false
+      alpine_node_24:
+        description: 'Alpine + Node 24'
+        type: boolean
+        default: true
+      debian_node_22:
+        description: 'Debian + Node 22'
+        type: boolean
+        default: false
+      debian_node_24:
+        description: 'Debian + Node 24'
+        type: boolean
+        default: false
 
 env:
   GHCR_REGISTRY: ghcr.io
@@ -184,8 +196,10 @@ jobs:
           path: ./signalk-server/*.tgz
 
   # Computes which variants are enabled and emits matrices used by the
-  # build / manifest / copy jobs. Centralising this here removes the
-  # per-job "is this enabled?" boilerplate and the long shell tag-builder.
+  # build / manifest / copy jobs. The OS x Node catalogue lives in
+  # .github/build-matrix.json - this step just cross-products it and
+  # filters by the per-row workflow_dispatch checkboxes (or by
+  # default_enabled for scheduled runs).
   prepare:
     name: Prepare matrices and tags
     needs: [signalk-server]
@@ -195,65 +209,60 @@ jobs:
       variant_matrix: ${{ steps.matrix.outputs.variant_matrix }}
       any_enabled: ${{ steps.matrix.outputs.any_enabled }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
       - name: Compute matrices
         id: matrix
         env:
-          ALPINE: ${{ github.event.inputs.build_docker_tags_alpine }}
-          DEBIAN: ${{ github.event.inputs.build_docker_tags_debian }}
-          UBUNTU_2404: ${{ github.event.inputs.build_ubuntu_2404 }}
-          UBUNTU_2604: ${{ github.event.inputs.build_ubuntu_2604 }}
-          NODE_22: ${{ github.event.inputs.build_node_22 }}
-          NODE_24: ${{ github.event.inputs.build_node_24 }}
           TAG: ${{ needs.signalk-server.outputs.tag }}
           MAJOR_V: v${{ needs.signalk-server.outputs.major }}
           MINOR_V: v${{ needs.signalk-server.outputs.major }}.${{ needs.signalk-server.outputs.minor }}
           GHCR_PREFIX: ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}
           HUB_PREFIX: ${{ env.DOCKER_HUB_REPO }}
+          ENABLED_JSON: ${{ toJSON(github.event.inputs) }}
         run: |
           set -euo pipefail
           IS_BETA=$([[ "$TAG" == *beta* ]] && echo "true" || echo "false")
 
-          # Variant catalogue. To add a new OS / Node combo, add a row here.
-          # manifest_short_tags[0] is the "primary" short tag also mirrored to Docker Hub.
-          # When triggered by schedule, all event.inputs.* are empty strings -> defaults below.
-          variants=$(jq -nc \
-            --arg alpine "${ALPINE:-true}" \
-            --arg debian "${DEBIAN:-false}" \
-            --arg u2404 "${UBUNTU_2404:-true}" \
-            --arg u2604 "${UBUNTU_2604:-true}" \
-            --arg n22 "${NODE_22:-false}" \
-            --arg n24 "${NODE_24:-true}" \
+          # Cross-product os_variants x node_versions, filter by the
+          # per-row dispatch checkbox (or by default_enabled for scheduled runs),
+          # then attach full + short tags. manifest_short_tags[0] is mirrored
+          # to Docker Hub as the primary alias.
+          variants=$(jq -c \
             --arg tag "$TAG" \
             --arg major "$MAJOR_V" \
             --arg minor "$MINOR_V" \
             --arg ghcr "$GHCR_PREFIX" \
             --arg hub "$HUB_PREFIX" \
-            --arg isbeta "$IS_BETA" '
-            [
-              {os_label:"ubuntu",       os_arg:"24.04",  node:"22.x", manifest_short_tags:["latest-22.x"],                                   os_en:$u2404,  node_en:$n22},
-              {os_label:"ubuntu",       os_arg:"24.04",  node:"24.x", manifest_short_tags:["latest","latest-24.x"],                          os_en:$u2404,  node_en:$n24},
-              {os_label:"ubuntu-26.04", os_arg:"26.04",  node:"22.x", manifest_short_tags:["latest-ubuntu-26.04-22.x"],                      os_en:$u2604,  node_en:$n22},
-              {os_label:"ubuntu-26.04", os_arg:"26.04",  node:"24.x", manifest_short_tags:["latest-ubuntu-26.04","latest-ubuntu-26.04-24.x"], os_en:$u2604,  node_en:$n24},
-              {os_label:"alpine",       os_arg:"alpine", node:"22",   manifest_short_tags:["latest-alpine-22"],                              os_en:$alpine, node_en:$n22},
-              {os_label:"alpine",       os_arg:"alpine", node:"24",   manifest_short_tags:["latest-alpine"],                                 os_en:$alpine, node_en:$n24},
-              {os_label:"debian",       os_arg:"debian", node:"22",   manifest_short_tags:["latest-debian-22"],                              os_en:$debian, node_en:$n22},
-              {os_label:"debian",       os_arg:"debian", node:"24",   manifest_short_tags:["latest-debian"],                                 os_en:$debian, node_en:$n24}
-            ]
-            | map(select(.os_en == "true" and .node_en == "true"))
+            --arg isbeta "$IS_BETA" \
+            --argjson enabled "${ENABLED_JSON:-null}" '
+            (if ($enabled | type) == "object" then $enabled else {} end) as $en
+            | .os_variants as $os | .node_versions as $nodes
+            | [ $os[] as $o | $nodes[] as $n |
+                (($o.id | gsub("[-.]"; "_")) + "_node_" + $n.id) as $key |
+                {
+                  enabled: ($en[$key] // (if ($o.default_enabled and $n.default_enabled) then "true" else "false" end)),
+                  os_label: $o.user_os_label,
+                  os_arg:   $o.user_os_arg,
+                  node:     (if $o.family == "ubuntu" then $n.ubuntu_format else $n.id end),
+                  manifest_short_tags: ($o.manifest_short_tags[$n.id] // [])
+                }
+              ]
+            | map(select(.enabled == "true"))
             | map(
-                .os_label as $ol | .node as $n |
+                .os_label as $ol | .node as $nv |
                 . + {
                   primary_short_tag: .manifest_short_tags[0],
                   full_tags: (
                     (if $isbeta == "true" then [$tag, "latest"]
                      else [$tag, $major, $minor, "latest"] end)
-                    | map(["\($ghcr):\(.)-\($ol)-\($n)", "\($hub):\(.)-\($ol)-\($n)"])
+                    | map(["\($ghcr):\(.)-\($ol)-\($nv)", "\($hub):\(.)-\($ol)-\($nv)"])
                     | flatten
                   )
                 }
               )
-            | map(del(.os_en, .node_en))
-          ')
+            | map(del(.enabled))
+          ' .github/build-matrix.json)
 
           # Build matrix: one row per (variant, arch). Node 22 builds also produce arm/v7.
           build_matrix=$(echo "$variants" | jq -c '

--- a/.github/workflows/build sk docker container all.yml
+++ b/.github/workflows/build sk docker container all.yml
@@ -1,32 +1,43 @@
 name: SignalK Docker Build - Ubuntu + Alpine + Debian
 
 on:
+  # Per-(OS x Node) checkboxes. The catalogue of available combinations
+  # lives in .github/build-matrix.json - add a row there, then add a
+  # matching input below. Input names must be: <os_id_with_-_and_._mapped_to__>_node_<node_id>.
   workflow_dispatch:
     inputs:
-      build_docker_tags_alpine:
-        description: 'Build Alpine docker image'
-        type: boolean
-        default: true
-      build_docker_tags_debian:
-        description: 'Build Debian docker image'
+      ubuntu_24_04_node_22:
+        description: 'Ubuntu 24.04 + Node 22.x'
         type: boolean
         default: false
-      build_ubuntu_2404:
-        description: 'Build Ubuntu 24.04 docker image'
+      ubuntu_24_04_node_24:
+        description: 'Ubuntu 24.04 + Node 24.x'
         type: boolean
         default: true
-      build_ubuntu_2604:
-        description: 'Build Ubuntu 26.04 docker image'
-        type: boolean
-        default: true
-      build_node_22:
-        description: 'Build Node.js 22 images'
+      ubuntu_26_04_node_22:
+        description: 'Ubuntu 26.04 + Node 22.x'
         type: boolean
         default: false
-      build_node_24:
-        description: 'Build Node.js 24 images'
+      ubuntu_26_04_node_24:
+        description: 'Ubuntu 26.04 + Node 24.x'
         type: boolean
         default: true
+      alpine_node_22:
+        description: 'Alpine + Node 22'
+        type: boolean
+        default: false
+      alpine_node_24:
+        description: 'Alpine + Node 24'
+        type: boolean
+        default: true
+      debian_node_22:
+        description: 'Debian + Node 22'
+        type: boolean
+        default: false
+      debian_node_24:
+        description: 'Debian + Node 24'
+        type: boolean
+        default: false
 
 env:
   GHCR_REGISTRY: ghcr.io
@@ -104,8 +115,9 @@ jobs:
           path: ./signalk-server/*.tgz
 
   # Computes which variants are enabled and emits matrices used by the
-  # build / manifest / copy jobs. Centralising this here removes the
-  # per-job "is this enabled?" boilerplate and the long shell tag-builder.
+  # build / manifest / copy jobs. The OS x Node catalogue lives in
+  # .github/build-matrix.json - this step just cross-products it and
+  # filters by the per-row workflow_dispatch checkboxes.
   prepare:
     name: Prepare matrices and tags
     needs: [signalk-server]
@@ -115,64 +127,59 @@ jobs:
       variant_matrix: ${{ steps.matrix.outputs.variant_matrix }}
       any_enabled: ${{ steps.matrix.outputs.any_enabled }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
       - name: Compute matrices
         id: matrix
         env:
-          ALPINE: ${{ github.event.inputs.build_docker_tags_alpine }}
-          DEBIAN: ${{ github.event.inputs.build_docker_tags_debian }}
-          UBUNTU_2404: ${{ github.event.inputs.build_ubuntu_2404 }}
-          UBUNTU_2604: ${{ github.event.inputs.build_ubuntu_2604 }}
-          NODE_22: ${{ github.event.inputs.build_node_22 }}
-          NODE_24: ${{ github.event.inputs.build_node_24 }}
           TAG: ${{ needs.signalk-server.outputs.tag }}
           MAJOR_V: v${{ needs.signalk-server.outputs.major }}
           MINOR_V: v${{ needs.signalk-server.outputs.major }}.${{ needs.signalk-server.outputs.minor }}
           GHCR_PREFIX: ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_REPO }}
           HUB_PREFIX: ${{ env.DOCKER_HUB_REPO }}
+          ENABLED_JSON: ${{ toJSON(github.event.inputs) }}
         run: |
           set -euo pipefail
           IS_BETA=$([[ "$TAG" == *beta* ]] && echo "true" || echo "false")
 
-          # Variant catalogue. To add a new OS / node combo, add a row here.
-          # manifest_short_tags[0] is the "primary" short tag also mirrored to Docker Hub.
-          variants=$(jq -nc \
-            --arg alpine "$ALPINE" \
-            --arg debian "$DEBIAN" \
-            --arg u2404 "$UBUNTU_2404" \
-            --arg u2604 "$UBUNTU_2604" \
-            --arg n22 "$NODE_22" \
-            --arg n24 "$NODE_24" \
+          # Cross-product os_variants x node_versions, filter by the
+          # per-row dispatch checkbox, then attach full + short tags.
+          # manifest_short_tags[0] is mirrored to Docker Hub as the primary alias.
+          variants=$(jq -c \
             --arg tag "$TAG" \
             --arg major "$MAJOR_V" \
             --arg minor "$MINOR_V" \
             --arg ghcr "$GHCR_PREFIX" \
             --arg hub "$HUB_PREFIX" \
-            --arg isbeta "$IS_BETA" '
-            [
-              {os_label:"ubuntu",       os_arg:"24.04",  node:"22.x", manifest_short_tags:["latest-22.x"],                                   os_en:$u2404,  node_en:$n22},
-              {os_label:"ubuntu",       os_arg:"24.04",  node:"24.x", manifest_short_tags:["latest","latest-24.x"],                          os_en:$u2404,  node_en:$n24},
-              {os_label:"ubuntu-26.04", os_arg:"26.04",  node:"22.x", manifest_short_tags:["latest-ubuntu-26.04-22.x"],                      os_en:$u2604,  node_en:$n22},
-              {os_label:"ubuntu-26.04", os_arg:"26.04",  node:"24.x", manifest_short_tags:["latest-ubuntu-26.04","latest-ubuntu-26.04-24.x"], os_en:$u2604,  node_en:$n24},
-              {os_label:"alpine",       os_arg:"alpine", node:"22",   manifest_short_tags:["latest-alpine-22"],                              os_en:$alpine, node_en:$n22},
-              {os_label:"alpine",       os_arg:"alpine", node:"24",   manifest_short_tags:["latest-alpine"],                                 os_en:$alpine, node_en:$n24},
-              {os_label:"debian",       os_arg:"debian", node:"22",   manifest_short_tags:["latest-debian-22"],                              os_en:$debian, node_en:$n22},
-              {os_label:"debian",       os_arg:"debian", node:"24",   manifest_short_tags:["latest-debian"],                                 os_en:$debian, node_en:$n24}
-            ]
-            | map(select(.os_en == "true" and .node_en == "true"))
+            --arg isbeta "$IS_BETA" \
+            --argjson enabled "${ENABLED_JSON:-null}" '
+            (if ($enabled | type) == "object" then $enabled else {} end) as $en
+            | .os_variants as $os | .node_versions as $nodes
+            | [ $os[] as $o | $nodes[] as $n |
+                (($o.id | gsub("[-.]"; "_")) + "_node_" + $n.id) as $key |
+                {
+                  enabled: ($en[$key] // (if ($o.default_enabled and $n.default_enabled) then "true" else "false" end)),
+                  os_label: $o.user_os_label,
+                  os_arg:   $o.user_os_arg,
+                  node:     (if $o.family == "ubuntu" then $n.ubuntu_format else $n.id end),
+                  manifest_short_tags: ($o.manifest_short_tags[$n.id] // [])
+                }
+              ]
+            | map(select(.enabled == "true"))
             | map(
-                .os_label as $ol | .node as $n |
+                .os_label as $ol | .node as $nv |
                 . + {
                   primary_short_tag: .manifest_short_tags[0],
                   full_tags: (
                     (if $isbeta == "true" then [$tag, "latest"]
                      else [$tag, $major, $minor, "latest"] end)
-                    | map(["\($ghcr):\(.)-\($ol)-\($n)", "\($hub):\(.)-\($ol)-\($n)"])
+                    | map(["\($ghcr):\(.)-\($ol)-\($nv)", "\($hub):\(.)-\($ol)-\($nv)"])
                     | flatten
                   )
                 }
               )
-            | map(del(.os_en, .node_en))
-          ')
+            | map(del(.enabled))
+          ' .github/build-matrix.json)
 
           # Build matrix: one row per (variant, arch). Node 22 builds also produce arm/v7.
           build_matrix=$(echo "$variants" | jq -c '


### PR DESCRIPTION
## Summary
Refactored the Docker build workflow configuration to use a centralized JSON file (`.github/build-matrix.json`) as the single source of truth for OS and Node.js version combinations, replacing hardcoded matrix definitions scattered across three workflow files.

## Key Changes

- **Created `.github/build-matrix.json`**: New configuration file that defines:
  - OS variants (Ubuntu 24.04, Ubuntu 26.04, Alpine, Debian) with their properties
  - Node.js versions (22, 24) with their properties
  - Default enabled states and manifest tags for each combination
  - Dockerfile paths and build/test flags for base image workflows

- **Updated workflow dispatch inputs**: Replaced individual OS and Node checkboxes with per-combination inputs following the pattern `<os_id>_node_<node_id>` (e.g., `ubuntu_24_04_node_22`, `alpine_node_24`)

- **Refactored matrix computation logic** in three workflows:
  - `build sk docker container 24h.yml`
  - `build sk docker container all.yml`
  - `build docker base container all.yml`
  
  The matrix preparation step now:
  - Checks out the repository to access `build-matrix.json`
  - Cross-products OS variants with Node versions
  - Filters by per-combination dispatch checkboxes (or `default_enabled` for scheduled runs)
  - Dynamically generates tags and build matrices from the JSON configuration

## Implementation Details

- The JSON structure supports extensibility: adding a new OS or Node version requires only updating the JSON file and adding corresponding workflow dispatch inputs
- Scheduled workflow runs ignore dispatch inputs and use `default_enabled` flags from the JSON
- The jq-based matrix computation now reads from the JSON file instead of using hardcoded variant arrays
- Maintains backward compatibility with existing tag naming and build behavior
- Reduces duplication across three workflow files by centralizing configuration

https://claude.ai/code/session_016fZmdkGdq5gc76ebDoynyM