### PR TITLE
refactor(workflows): centralize OS / Node / Arch config in build-matrix.json

### DIFF
--- a/.github/build-matrix.json
+++ b/.github/build-matrix.json
@@ -1,5 +1,19 @@
 {
-  "_comment": "Single source of truth for OS x Node combinations the workflows can build. To add a new OS, append an entry to os_variants and a matching workflow_dispatch input (one per node version) to .github/workflows/build sk docker container all.yml and build docker base container all.yml. To add a new Node major, append to node_versions and add manifest_short_tags entries on every os_variants row, plus matching workflow_dispatch inputs.",
+  "_comment": "Single source of truth for the OS x Node x Arch combinations the workflows can build. To add a new OS: append to os_variants and add matching workflow_dispatch inputs (one per node) to the SK and base workflows. To add a new Node major: append to node_versions, add manifest_short_tags entries on every os_variants row, and add matching workflow_dispatch inputs. To add a new build runner / arch: append to architectures (id_user is the SK-side arch suffix in tags, id_base is the base-side suffix - keep these stable to preserve existing GHCR tags). Per-node platform tweaks live on node_versions: extra_platforms[arch.id_user] is appended to the arch's base platform, and exclude_archs lists arch ids that should not be built for that node.",
+  "architectures": [
+    {
+      "id_user": "amd64",
+      "id_base": "amd",
+      "vm": "ubuntu-latest",
+      "platform": "linux/amd64"
+    },
+    {
+      "id_user": "arm64",
+      "id_base": "arm",
+      "vm": "ubuntu-24.04-arm",
+      "platform": "linux/arm64"
+    }
+  ],
   "os_variants": [
     {
       "id": "ubuntu-24.04",
@@ -66,12 +80,16 @@
     {
       "id": "22",
       "ubuntu_format": "22.x",
-      "default_enabled": false
+      "default_enabled": false,
+      "extra_platforms": { "arm64": "linux/arm/v7" },
+      "exclude_archs": []
     },
     {
       "id": "24",
       "ubuntu_format": "24.x",
-      "default_enabled": true
+      "default_enabled": true,
+      "extra_platforms": {},
+      "exclude_archs": []
     }
   ]
 }

--- a/.github/workflows/build docker base container all.yml
+++ b/.github/workflows/build docker base container all.yml
@@ -81,6 +81,7 @@ jobs:
                   family:     $o.family,
                   os_label:   $o.base_os_label,
                   node:       (if $o.family == "ubuntu" then $n.ubuntu_format else $n.id end),
+                  node_id:    $n.id,
                   dockerfile: $o.dockerfile,
                   build_test: $o.build_test,
                   login_dhi:  $o.login_dhi
@@ -90,14 +91,28 @@ jobs:
             | map(del(.enabled))
           ' .github/build-matrix.json)
 
-          # Build matrix: one row per (variant, arch). Node 22 builds also produce arm/v7.
-          # NB: arch suffix is amd/arm (not amd64/arm64) to match existing base image tags.
-          build_matrix=$(echo "$variants" | jq -c '
-            [ .[] |
-              . + {arch: "amd", vm: "ubuntu-latest",   platform: "linux/amd64"},
-              . + {arch: "arm", vm: "ubuntu-24.04-arm",
-                   platform: (if (.node | startswith("22")) then "linux/arm64,linux/arm/v7" else "linux/arm64" end)}
-            ]')
+          # Build matrix: cross-product variants x architectures.
+          # Per-node extra_platforms append to the arch's base platform
+          # (e.g. Node 22 adds linux/arm/v7 to arm64). exclude_archs drops
+          # archs entirely for a given node. Both lists are defined in
+          # .github/build-matrix.json on the node_versions row.
+          # NB: arch suffix is amd/arm (id_base) - kept stable to match existing base image tags.
+          build_matrix=$(jq -c \
+            --argjson variants "$variants" '
+            (.node_versions | map({(.id): .}) | add) as $node_index
+            | .architectures as $archs
+            | [ $variants[] as $v |
+                $node_index[$v.node_id] as $n |
+                $archs[] as $a |
+                select(((($n.exclude_archs // []) | index($a.id_user)) | not)) |
+                (($n.extra_platforms // {})[$a.id_user] // "") as $extra |
+                ($v + {
+                  arch:     $a.id_base,
+                  vm:       $a.vm,
+                  platform: (if $extra == "" then $a.platform else "\($a.platform),\($extra)" end)
+                })
+              ]
+          ' .github/build-matrix.json)
 
           # Variant matrix: one row per variant (used by manifest + copy jobs).
           variant_matrix=$(echo "$variants" | jq -c '[ .[] | {os_label, node} ]')

--- a/.github/workflows/build sk docker container 24h.yml
+++ b/.github/workflows/build sk docker container 24h.yml
@@ -245,6 +245,7 @@ jobs:
                   os_label: $o.user_os_label,
                   os_arg:   $o.user_os_arg,
                   node:     (if $o.family == "ubuntu" then $n.ubuntu_format else $n.id end),
+                  node_id:  $n.id,
                   manifest_short_tags: ($o.manifest_short_tags[$n.id] // [])
                 }
               ]
@@ -264,13 +265,30 @@ jobs:
             | map(del(.enabled))
           ' .github/build-matrix.json)
 
-          # Build matrix: one row per (variant, arch). Node 22 builds also produce arm/v7.
-          build_matrix=$(echo "$variants" | jq -c '
-            [ .[] |
-              {os_label, os_arg, node, arch: "amd64", vm: "ubuntu-latest",   platform: "linux/amd64"},
-              {os_label, os_arg, node, arch: "arm64", vm: "ubuntu-24.04-arm",
-               platform: (if (.node | startswith("22")) then "linux/arm64,linux/arm/v7" else "linux/arm64" end)}
-            ]')
+          # Build matrix: cross-product variants x architectures.
+          # Per-node extra_platforms append to the arch's base platform
+          # (e.g. Node 22 adds linux/arm/v7 to arm64). exclude_archs drops
+          # archs entirely for a given node. Both lists are defined in
+          # .github/build-matrix.json on the node_versions row.
+          build_matrix=$(jq -c \
+            --argjson variants "$variants" '
+            (.node_versions | map({(.id): .}) | add) as $node_index
+            | .architectures as $archs
+            | [ $variants[] as $v |
+                $node_index[$v.node_id] as $n |
+                $archs[] as $a |
+                select(((($n.exclude_archs // []) | index($a.id_user)) | not)) |
+                (($n.extra_platforms // {})[$a.id_user] // "") as $extra |
+                {
+                  os_label: $v.os_label,
+                  os_arg:   $v.os_arg,
+                  node:     $v.node,
+                  arch:     $a.id_user,
+                  vm:       $a.vm,
+                  platform: (if $extra == "" then $a.platform else "\($a.platform),\($extra)" end)
+                }
+              ]
+          ' .github/build-matrix.json)
 
           # Variant matrix: one row per variant (used by manifest + copy jobs).
           variant_matrix=$(echo "$variants" | jq -c '

--- a/.github/workflows/build sk docker container all.yml
+++ b/.github/workflows/build sk docker container all.yml
@@ -162,6 +162,7 @@ jobs:
                   os_label: $o.user_os_label,
                   os_arg:   $o.user_os_arg,
                   node:     (if $o.family == "ubuntu" then $n.ubuntu_format else $n.id end),
+                  node_id:  $n.id,
                   manifest_short_tags: ($o.manifest_short_tags[$n.id] // [])
                 }
               ]
@@ -181,13 +182,30 @@ jobs:
             | map(del(.enabled))
           ' .github/build-matrix.json)
 
-          # Build matrix: one row per (variant, arch). Node 22 builds also produce arm/v7.
-          build_matrix=$(echo "$variants" | jq -c '
-            [ .[] |
-              {os_label, os_arg, node, arch: "amd64", vm: "ubuntu-latest",   platform: "linux/amd64"},
-              {os_label, os_arg, node, arch: "arm64", vm: "ubuntu-24.04-arm",
-               platform: (if (.node | startswith("22")) then "linux/arm64,linux/arm/v7" else "linux/arm64" end)}
-            ]')
+          # Build matrix: cross-product variants x architectures.
+          # Per-node extra_platforms append to the arch's base platform
+          # (e.g. Node 22 adds linux/arm/v7 to arm64). exclude_archs drops
+          # archs entirely for a given node. Both lists are defined in
+          # .github/build-matrix.json on the node_versions row.
+          build_matrix=$(jq -c \
+            --argjson variants "$variants" '
+            (.node_versions | map({(.id): .}) | add) as $node_index
+            | .architectures as $archs
+            | [ $variants[] as $v |
+                $node_index[$v.node_id] as $n |
+                $archs[] as $a |
+                select(((($n.exclude_archs // []) | index($a.id_user)) | not)) |
+                (($n.extra_platforms // {})[$a.id_user] // "") as $extra |
+                {
+                  os_label: $v.os_label,
+                  os_arg:   $v.os_arg,
+                  node:     $v.node,
+                  arch:     $a.id_user,
+                  vm:       $a.vm,
+                  platform: (if $extra == "" then $a.platform else "\($a.platform),\($extra)" end)
+                }
+              ]
+          ' .github/build-matrix.json)
 
           # Variant matrix: one row per variant (used by manifest + copy jobs).
           variant_matrix=$(echo "$variants" | jq -c '


### PR DESCRIPTION
## Summary

Adds `.github/build-matrix.json` as the single source of truth for OS × Node × Arch combinations the CI builds. Adding a new OS, Node major, or build runner is now a JSON edit (plus matching `workflow_dispatch` checkboxes for filtering).

### `build-matrix.json` shape
- `os_variants[]` — family, base / user OS labels, dockerfile, `build_test`, `login_dhi`, per-node `manifest_short_tags`, `default_enabled`.
- `node_versions[]` — `id`, `ubuntu_format` (`.x` for ubuntu nodesource), `default_enabled`, plus:
  - `extra_platforms` — arch-id-keyed string appended to the arch's base platform (Node 22 sets `arm64 → linux/arm/v7`).
  - `exclude_archs` — list of arch ids that should not be built for that node.
- `architectures[]` — `id_user` (SK-side suffix, e.g. `amd64`), `id_base` (base-side suffix, e.g. `amd`), `vm`, base `platform`. Both id forms stay in the JSON so existing GHCR / Docker Hub tags are unchanged.

### Workflow changes
Refactored to read the JSON in `prepare`, cross-product OS × Node × Arch, and filter by per-row checkboxes:
- `.github/workflows/build sk docker container all.yml`
- `.github/workflows/build sk docker container 24h.yml`
- `.github/workflows/build docker base container all.yml`

The 6 cross-product booleans are replaced by 8 per-(OS × Node) checkboxes (`ubuntu_24_04_node_24`, `alpine_node_22`, …). Scheduled runs ignore inputs and fall back to `default_enabled` from the JSON. `build sk docker container all org.yml` is left untouched (its pre-matrix layout would need a full rewrite, not a config swap).

### Compatibility
Verified locally that with current `default_enabled` flags both the build matrix and the variant matrix are byte-identical to the previous hand-coded output:
- Same three default variants (ubuntu-24.04 / ubuntu-26.04 / alpine on Node 24).
- Node 22 + arm64 still produces `linux/arm64,linux/arm/v7`; Node 24 + arm64 stays `linux/arm64`.
- Tag suffixes (`amd64`/`arm64` for SK, `amd`/`arm` for base) preserved.
- `manifest_short_tags` per (OS × Node) reproduce existing aliases (e.g. `latest`, `latest-24.x`, `latest-ubuntu-26.04`, `latest-alpine`).

### Adding new versions after this PR
- New OS family / version: append a row to `os_variants` and add a checkbox per node version to each workflow.
- New Node major: append to `node_versions`, add `manifest_short_tags` entries on every `os_variants` row, and add matching checkboxes.
- New build runner / arch: append a row to `architectures`. (Note: the downstream `Wait for arch images` loop and `manifest sources` blocks still hardcode `amd64`/`arm64` and `amd`/`arm`; today's two-arch setup is unaffected, but adding a third arch would need a follow-up to wire those through the JSON.)

## Test plan
- [ ] Trigger `build sk docker container all.yml` via `workflow_dispatch` with default inputs and confirm it builds the same three variants with the same tags as before.
- [ ] Trigger `build docker base container all.yml` via `workflow_dispatch` with default inputs and confirm same behavior.
- [ ] Wait for the next scheduled run of `build sk docker container 24h.yml` (or trigger manually) and confirm it still builds when a new upstream `v*` tag is detected.
- [ ] Tick a Node-22 checkbox (e.g. `alpine_node_22`) and confirm the resulting arm64 build still includes `linux/arm/v7`.

https://claude.ai/code/session_016fZmdkGdq5gc76ebDoynyM

---
_Generated by [Claude Code](https://claude.ai/code/session_016fZmdkGdq5gc76ebDoynyM)_