### PR TITLE
Simplify build matrix configuration and workflow logic

### DIFF
--- a/.github/build-matrix.json
+++ b/.github/build-matrix.json
@@ -1,26 +1,15 @@
 {
-  "_comment": "Single source of truth for the OS x Node x Arch combinations the workflows can build. To add a new OS: append to os_variants and add matching workflow_dispatch inputs (one per node) to the SK and base workflows. To add a new Node major: append to node_versions, add manifest_short_tags entries on every os_variants row, and add matching workflow_dispatch inputs. To add a new build runner / arch: append to architectures (id_user is the SK-side arch suffix in tags, id_base is the base-side suffix - keep these stable to preserve existing GHCR tags). Per-node platform tweaks live on node_versions: extra_platforms[arch.id_user] is appended to the arch's base platform, and exclude_archs lists arch ids that should not be built for that node.",
+  "_comment": "Single source of truth for the OS x Node x Arch combinations the workflows can build. To add a new OS: append to os_variants and add matching workflow_dispatch inputs (one per node) to the SK and base workflows. To add a new Node major: append to node_versions, add manifest_short_tags entries on every os_variants row, and add matching workflow_dispatch inputs. To add a new build runner / arch: append to architectures (id_user is the SK-side arch suffix in tags, id_base is the base-side suffix - keep these stable to preserve existing GHCR tags). Per-node platform tweaks live on node_versions: extra_platforms[arch.id_user] is appended to the arch's base platform, exclude_archs (optional) lists arch ids that should not be built for that node. user_os_label is optional and defaults to id (override only when the SK-side label differs, e.g. ubuntu-24.04 -> ubuntu). For ubuntu family the node label in image tags is rendered as '<node>.x'; for other families it is '<node>'.",
   "architectures": [
-    {
-      "id_user": "amd64",
-      "id_base": "amd",
-      "vm": "ubuntu-latest",
-      "platform": "linux/amd64"
-    },
-    {
-      "id_user": "arm64",
-      "id_base": "arm",
-      "vm": "ubuntu-24.04-arm",
-      "platform": "linux/arm64"
-    }
+    { "id_user": "amd64", "id_base": "amd", "vm": "ubuntu-latest",    "platform": "linux/amd64" },
+    { "id_user": "arm64", "id_base": "arm", "vm": "ubuntu-24.04-arm", "platform": "linux/arm64" }
   ],
   "os_variants": [
     {
       "id": "ubuntu-24.04",
       "family": "ubuntu",
-      "base_os_label": "24.04",
+      "os_arg": "24.04",
       "user_os_label": "ubuntu",
-      "user_os_arg": "24.04",
       "dockerfile": "./docker/Dockerfile_base_24.04_user",
       "build_test": true,
       "login_dhi": false,
@@ -33,9 +22,7 @@
     {
       "id": "ubuntu-26.04",
       "family": "ubuntu",
-      "base_os_label": "26.04",
-      "user_os_label": "ubuntu-26.04",
-      "user_os_arg": "26.04",
+      "os_arg": "26.04",
       "dockerfile": "./docker/Dockerfile_base_26.04_user",
       "build_test": true,
       "login_dhi": false,
@@ -48,9 +35,7 @@
     {
       "id": "alpine",
       "family": "alpine",
-      "base_os_label": "alpine",
-      "user_os_label": "alpine",
-      "user_os_arg": "alpine",
+      "os_arg": "alpine",
       "dockerfile": "./docker/Dockerfile_base_alpine",
       "build_test": false,
       "login_dhi": true,
@@ -63,9 +48,7 @@
     {
       "id": "debian",
       "family": "debian",
-      "base_os_label": "debian",
-      "user_os_label": "debian",
-      "user_os_arg": "debian",
+      "os_arg": "debian",
       "dockerfile": "./docker/Dockerfile_base_debian",
       "build_test": false,
       "login_dhi": false,
@@ -77,19 +60,7 @@
     }
   ],
   "node_versions": [
-    {
-      "id": "22",
-      "ubuntu_format": "22.x",
-      "default_enabled": false,
-      "extra_platforms": { "arm64": "linux/arm/v7" },
-      "exclude_archs": []
-    },
-    {
-      "id": "24",
-      "ubuntu_format": "24.x",
-      "default_enabled": true,
-      "extra_platforms": {},
-      "exclude_archs": []
-    }
+    { "id": "22", "default_enabled": false, "extra_platforms": { "arm64": "linux/arm/v7" } },
+    { "id": "24", "default_enabled": true,  "extra_platforms": {} }
   ]
 }

--- a/.github/workflows/build docker base container all.yml
+++ b/.github/workflows/build docker base container all.yml
@@ -79,8 +79,8 @@ jobs:
                 {
                   enabled: ($en[$key] // (if ($o.default_enabled and $n.default_enabled) then "true" else "false" end)),
                   family:     $o.family,
-                  os_label:   $o.base_os_label,
-                  node:       (if $o.family == "ubuntu" then $n.ubuntu_format else $n.id end),
+                  os_label:   $o.os_arg,
+                  node:       (if $o.family == "ubuntu" then "\($n.id).x" else $n.id end),
                   node_id:    $n.id,
                   dockerfile: $o.dockerfile,
                   build_test: $o.build_test,

--- a/.github/workflows/build sk docker container 24h.yml
+++ b/.github/workflows/build sk docker container 24h.yml
@@ -242,9 +242,9 @@ jobs:
                 (($o.id | gsub("[-.]"; "_")) + "_node_" + $n.id) as $key |
                 {
                   enabled: ($en[$key] // (if ($o.default_enabled and $n.default_enabled) then "true" else "false" end)),
-                  os_label: $o.user_os_label,
-                  os_arg:   $o.user_os_arg,
-                  node:     (if $o.family == "ubuntu" then $n.ubuntu_format else $n.id end),
+                  os_label: ($o.user_os_label // $o.id),
+                  os_arg:   $o.os_arg,
+                  node:     (if $o.family == "ubuntu" then "\($n.id).x" else $n.id end),
                   node_id:  $n.id,
                   manifest_short_tags: ($o.manifest_short_tags[$n.id] // [])
                 }

--- a/.github/workflows/build sk docker container all.yml
+++ b/.github/workflows/build sk docker container all.yml
@@ -159,9 +159,9 @@ jobs:
                 (($o.id | gsub("[-.]"; "_")) + "_node_" + $n.id) as $key |
                 {
                   enabled: ($en[$key] // (if ($o.default_enabled and $n.default_enabled) then "true" else "false" end)),
-                  os_label: $o.user_os_label,
-                  os_arg:   $o.user_os_arg,
-                  node:     (if $o.family == "ubuntu" then $n.ubuntu_format else $n.id end),
+                  os_label: ($o.user_os_label // $o.id),
+                  os_arg:   $o.os_arg,
+                  node:     (if $o.family == "ubuntu" then "\($n.id).x" else $n.id end),
                   node_id:  $n.id,
                   manifest_short_tags: ($o.manifest_short_tags[$n.id] // [])
                 }


### PR DESCRIPTION
## Summary
Refactored the build matrix configuration to reduce redundancy and simplify the workflow logic by consolidating OS label and argument fields, removing unnecessary node version metadata, and updating jq expressions to compute values dynamically.

## Key Changes

- **Consolidated OS configuration fields**: Replaced separate `base_os_label`, `user_os_label`, and `user_os_arg` fields with a single `os_arg` field. The `user_os_label` is now optional and defaults to the OS `id` if not specified.

- **Simplified node version entries**: Removed `ubuntu_format` field from node versions. The node label format is now computed directly in workflows using conditional logic: `<node>.x` for ubuntu family, `<node>` for others.

- **Updated workflow jq expressions**: Modified build matrix generation in all three workflows to:
  - Use `($o.user_os_label // $o.id)` to provide a default OS label
  - Reference the unified `$o.os_arg` field instead of separate user/base arguments
  - Compute node formatting inline: `"\($n.id).x"` for ubuntu, `$n.id` for others

- **Cleaned up architecture and node definitions**: Reformatted JSON for better readability while maintaining functionality.

- **Updated documentation**: Enhanced the build-matrix.json comment to clarify the new optional fields and node label rendering behavior.

## Implementation Details

The changes maintain backward compatibility in behavior while reducing configuration complexity. The workflows now derive node labels and formats dynamically based on OS family, eliminating the need to maintain separate format strings in the configuration file. This makes it easier to add new OS variants and node versions without duplicating label information.

https://claude.ai/code/session_01AuehmJZEz2mWV2n21XpRQ6