### PR TITLE
Replace git ls-remote with GitHub API for fetching latest release tag

### DIFF
--- a/.github/workflows/build sk docker container 24h.yml
+++ b/.github/workflows/build sk docker container 24h.yml
@@ -150,9 +150,8 @@ jobs:
       - name: signalk-server tags
         id: tags
         run: |
-          tag=$(git ls-remote --tags --refs --sort='-v:refname' \
-                  https://github.com/SignalK/signalk-server.git \
-                | head -n1 | sed 's|.*/||')
+          tag=$(curl -fsSL https://api.github.com/repos/SignalK/signalk-server/releases/latest \
+                | jq -r .tag_name)
           echo "tag=$tag" >> $GITHUB_OUTPUT
           echo "Extracted tag: $tag"
 

--- a/.github/workflows/build sk docker container all.yml
+++ b/.github/workflows/build sk docker container all.yml
@@ -65,9 +65,8 @@ jobs:
       - name: signalk-server tags
         id: tags
         run: |
-          tag=$(git ls-remote --tags --refs --sort='-v:refname' \
-                  https://github.com/SignalK/signalk-server.git \
-                | head -n1 | sed 's|.*/||')
+          tag=$(curl -fsSL https://api.github.com/repos/SignalK/signalk-server/releases/latest \
+                | jq -r .tag_name)
           # tag=v2.21.3
           echo "tag=$tag" >> $GITHUB_OUTPUT
           echo "Extracted tag: $tag"


### PR DESCRIPTION
## Summary
Updated the workflow scripts to use the GitHub API instead of `git ls-remote` for fetching the latest SignalK server release tag. This change improves reliability and simplifies the tag extraction logic.

## Key Changes
- Replaced `git ls-remote --tags --refs --sort='-v:refname'` with `curl` call to GitHub's `/releases/latest` API endpoint
- Simplified tag extraction by using `jq -r .tag_name` instead of `head -n1 | sed 's|.*/||'`
- Applied changes to both workflow files:
  - `.github/workflows/build sk docker container 24h.yml`
  - `.github/workflows/build sk docker container all.yml`

## Implementation Details
- Uses `curl -fsSL` for silent, secure HTTP requests to the GitHub API
- Leverages the `/repos/SignalK/signalk-server/releases/latest` endpoint which directly returns the latest release
- The `jq -r .tag_name` command extracts the tag name cleanly without additional string manipulation
- This approach is more direct and less prone to parsing errors compared to the previous git-based method

https://claude.ai/code/session_013v3tVrkk5ifU4WdJygP19m