### PR TITLE
Update signalk-server version detection method in Docker build

### DIFF
--- a/.github/workflows/build sk docker container all.yml
+++ b/.github/workflows/build sk docker container all.yml
@@ -65,8 +65,9 @@ jobs:
       - name: signalk-server tags
         id: tags
         run: |
-          tag=$(curl -fsSL https://api.github.com/repos/SignalK/signalk-server/releases/latest \
-                | jq -r .tag_name)
+          version=$(curl -fsSL https://raw.githubusercontent.com/SignalK/signalk-server/master/package.json \
+                | jq -r .version)
+          tag="v$version"
           # tag=v2.21.3
           echo "tag=$tag" >> $GITHUB_OUTPUT
           echo "Extracted tag: $tag"


### PR DESCRIPTION
## Summary
Changed the method for extracting the signalk-server version in the Docker build workflow from querying the GitHub releases API to reading directly from the master branch's package.json file.

## Key Changes
- Replaced GitHub releases API call (`/releases/latest`) with direct package.json fetch from master branch
- Changed version extraction from `tag_name` field to `version` field in package.json
- Updated tag construction to prepend "v" prefix to the extracted version string

## Implementation Details
This change improves reliability by:
- Eliminating dependency on GitHub's releases API, which may have rate limiting or availability issues
- Using the authoritative version source (package.json) directly from the master branch
- Ensuring the Docker build always uses the latest development version rather than the latest release tag

https://claude.ai/code/session_01Bg5GdojcwYNk5kjJDdyv8B