### PR TITLE
Add path-to-regexp dependency

### DIFF
--- a/patch/03-path-to-regexp/path-to-regexp.patch
+++ b/patch/03-path-to-regexp/path-to-regexp.patch
@@ -1,0 +1,11 @@
+diff --git a/package.json b/package.json
+--- a/package.json
++++ b/package.json
+@@ -120,6 +120,7 @@
+     "ncp": "^2.0.0",
+     "openid-client": "^6.8.4",
+     "ora": "^5.4.1",
++    "path-to-regexp": "~0.1.12",
+     "primus": "^7.3.5",
+     "prompts": "^2.4.2",
+     "rehype-parse": "^9.0.1",


### PR DESCRIPTION
## Summary
This change adds the `path-to-regexp` package as a dependency to the project.

## Changes
- Added `path-to-regexp` version `~0.1.12` to package.json dependencies

## Details
The `path-to-regexp` library is being introduced as a project dependency. This utility is commonly used for converting Express-style path strings (with parameters like `:id`) into regular expressions for route matching and path parsing.

https://claude.ai/code/session_01RE9RQVySsvKxwPtUXyz89A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the `path-to-regexp` package as a project dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->