### PR TITLE
Add Node 26.x support to Docker build workflows

### DIFF
--- a/.github/workflows/build docker base container all.yml
+++ b/.github/workflows/build docker base container all.yml
@@ -18,12 +18,20 @@ on:
         description: 'Ubuntu 24.04 + Node 24.x'
         type: boolean
         default: true
+      ubuntu_24_04_node_26:
+        description: 'Ubuntu 24.04 + Node 26.x'
+        type: boolean
+        default: true
       ubuntu_26_04_node_22:
         description: 'Ubuntu 26.04 + Node 22.x'
         type: boolean
         default: false
       ubuntu_26_04_node_24:
         description: 'Ubuntu 26.04 + Node 24.x'
+        type: boolean
+        default: true
+      ubuntu_26_04_node_26:
+        description: 'Ubuntu 26.04 + Node 26.x'
         type: boolean
         default: true
       alpine_node_22:
@@ -34,12 +42,20 @@ on:
         description: 'Alpine + Node 24'
         type: boolean
         default: true
+      alpine_node_26:
+        description: 'Alpine + Node 26'
+        type: boolean
+        default: true
       debian_node_22:
         description: 'Debian + Node 22'
         type: boolean
         default: false
       debian_node_24:
         description: 'Debian + Node 24'
+        type: boolean
+        default: false
+      debian_node_26:
+        description: 'Debian + Node 26'
         type: boolean
         default: false
       # <<< END auto-generated dispatch inputs

--- a/.github/workflows/build sk docker container 24h.yml
+++ b/.github/workflows/build sk docker container 24h.yml
@@ -18,12 +18,20 @@ on:
         description: 'Ubuntu 24.04 + Node 24.x'
         type: boolean
         default: true
+      ubuntu_24_04_node_26:
+        description: 'Ubuntu 24.04 + Node 26.x'
+        type: boolean
+        default: true
       ubuntu_26_04_node_22:
         description: 'Ubuntu 26.04 + Node 22.x'
         type: boolean
         default: false
       ubuntu_26_04_node_24:
         description: 'Ubuntu 26.04 + Node 24.x'
+        type: boolean
+        default: true
+      ubuntu_26_04_node_26:
+        description: 'Ubuntu 26.04 + Node 26.x'
         type: boolean
         default: true
       alpine_node_22:
@@ -34,12 +42,20 @@ on:
         description: 'Alpine + Node 24'
         type: boolean
         default: true
+      alpine_node_26:
+        description: 'Alpine + Node 26'
+        type: boolean
+        default: true
       debian_node_22:
         description: 'Debian + Node 22'
         type: boolean
         default: false
       debian_node_24:
         description: 'Debian + Node 24'
+        type: boolean
+        default: false
+      debian_node_26:
+        description: 'Debian + Node 26'
         type: boolean
         default: false
       # <<< END auto-generated dispatch inputs

--- a/.github/workflows/build sk docker container all.yml
+++ b/.github/workflows/build sk docker container all.yml
@@ -15,12 +15,20 @@ on:
         description: 'Ubuntu 24.04 + Node 24.x'
         type: boolean
         default: true
+      ubuntu_24_04_node_26:
+        description: 'Ubuntu 24.04 + Node 26.x'
+        type: boolean
+        default: true
       ubuntu_26_04_node_22:
         description: 'Ubuntu 26.04 + Node 22.x'
         type: boolean
         default: false
       ubuntu_26_04_node_24:
         description: 'Ubuntu 26.04 + Node 24.x'
+        type: boolean
+        default: true
+      ubuntu_26_04_node_26:
+        description: 'Ubuntu 26.04 + Node 26.x'
         type: boolean
         default: true
       alpine_node_22:
@@ -31,12 +39,20 @@ on:
         description: 'Alpine + Node 24'
         type: boolean
         default: true
+      alpine_node_26:
+        description: 'Alpine + Node 26'
+        type: boolean
+        default: true
       debian_node_22:
         description: 'Debian + Node 22'
         type: boolean
         default: false
       debian_node_24:
         description: 'Debian + Node 24'
+        type: boolean
+        default: false
+      debian_node_26:
+        description: 'Debian + Node 26'
         type: boolean
         default: false
       # <<< END auto-generated dispatch inputs


### PR DESCRIPTION
## Summary
This PR adds support for Node 26.x across all Docker build workflow configurations, enabling builds with the latest Node.js version alongside existing Ubuntu, Alpine, and Debian base images.

## Key Changes
- Added `ubuntu_24_04_node_26` workflow input for Ubuntu 24.04 + Node 26.x builds (enabled by default)
- Added `ubuntu_26_04_node_26` workflow input for Ubuntu 26.04 + Node 26.x builds (enabled by default)
- Added `alpine_node_26` workflow input for Alpine + Node 26 builds (enabled by default)
- Added `debian_node_26` workflow input for Debian + Node 26 builds (disabled by default)
- Updated all three workflow files:
  - `.github/workflows/build docker base container all.yml`
  - `.github/workflows/build sk docker container 24h.yml`
  - `.github/workflows/build sk docker container all.yml`

## Implementation Details
- Node 26.x inputs follow the same pattern as existing Node 22.x and 24.x configurations
- Default values align with existing conventions: enabled for Ubuntu and Alpine, disabled for Debian
- All changes are auto-generated dispatch inputs (marked within `# <<< END auto-generated dispatch inputs` comments)

https://claude.ai/code/session_019FzNB3GohvCSmEquZdPPc4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Node.js 26 build selections for Ubuntu 24.04, Ubuntu 26.04, Alpine, and Debian-based Docker images.
  * Enabled Node.js 26 by default for Ubuntu and Alpine builds; Debian builds remain disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->